### PR TITLE
Fix continue to load next scene

### DIFF
--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -882,8 +882,10 @@ saveGame() {
       return;
     }
     
-    // For any other input, revert to normal mode and continue the game
+    // For the continue command, load the stored next scene and resume gameplay
     if (input === "continue" || input === "c") {
+      this.game.currentScene = this.game.nextSceneToLoad;
+      this.game.nextSceneToLoad = null;
       this.game.inputMode = "normal";
       this.game.gameLogic.playScene();
     }


### PR DESCRIPTION
## Summary
- update `handleAwaitContinueInput` so that "continue" correctly loads the next scene

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f84ec487883289978350218df0f81