### PR TITLE
Use combatDelay constant across combat system

### DIFF
--- a/js/combat.js
+++ b/js/combat.js
@@ -1,4 +1,4 @@
-import { maxPlayerHealth, xpPerLevel } from './constants.js';
+import { maxPlayerHealth, xpPerLevel, combatDelay } from './constants.js';
 import { WeaponManager } from './weaponManager.js';
 
 const weaponManager = new WeaponManager();
@@ -98,9 +98,9 @@ export class CombatSystem {
     
     // If enemy goes first, process their turn
     if (!this.playerTurn) {
-      setTimeout(() => this.processEnemyTurn(), 1500);
+      setTimeout(() => this.processEnemyTurn(), combatDelay);
     } else {
-      this.showCombatOptions();
+      setTimeout(() => this.showCombatOptions(), combatDelay);
     }
     
     this.game.inputMode = "combat";
@@ -182,7 +182,7 @@ export class CombatSystem {
     
     // Set up enemy turn after a delay
     this.playerTurn = false;
-    setTimeout(() => this.processEnemyTurn(), 1500);
+    setTimeout(() => this.processEnemyTurn(), combatDelay);
   }
 
   processEnemyTurn() {
@@ -234,7 +234,7 @@ export class CombatSystem {
     setTimeout(() => {
       this.displayCombatStatus();
       this.showCombatOptions();
-    }, 1500);
+    }, combatDelay);
   }
 
   checkEnemy() {
@@ -255,7 +255,7 @@ export class CombatSystem {
     // Return to combat options after a short delay
     setTimeout(() => {
       this.showCombatOptions();
-    }, 1500);
+    }, combatDelay);
   }
 
   showInventory() {
@@ -341,7 +341,7 @@ export class CombatSystem {
 
     this.playerTurn = false;
     this.game.inputMode = "combat";
-    setTimeout(() => this.processEnemyTurn(), 1500);
+    setTimeout(() => this.processEnemyTurn(), combatDelay);
   }
 
   useItem(itemIndex) {
@@ -375,7 +375,7 @@ export class CombatSystem {
     this.game.inputMode = "combat";
     
     // Enemy turn after delay
-    setTimeout(() => this.processEnemyTurn(), 1500);
+    setTimeout(() => this.processEnemyTurn(), combatDelay);
   }
 
   applyItemEffect(item) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -15,3 +15,5 @@ export const initialPlayerHealth = 100;
 export const maxPlayerHealth = 100;
 export const initialPlayerXp = 0;
 export const xpPerLevel = 100; // XP needed for each level
+export const combatDelay = 2000; // delay between combat turns in milliseconds
+


### PR DESCRIPTION
## Summary
- define `combatDelay` in `constants.js`
- import the new constant in `combat.js`
- delay player options using `combatDelay` when combat starts
- replace other hardcoded `1500`ms delays in `CombatSystem` with `combatDelay`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840b93f39bc832894faa56897cb2e0f