### PR TITLE
Implement Intelligence and attack variance

### DIFF
--- a/js/combat.js
+++ b/js/combat.js
@@ -142,9 +142,13 @@ export class CombatSystem {
   // Update the playerAttack method to use equipment manager
   playerAttack() {
     const weapon = this.getEquippedWeapon();
-    const weaponDamage = this.game.equipmentManager ? 
-      this.game.equipmentManager.getWeaponDamage() : 
-      (weapon.damage + Math.floor(this.game.playerStats.attack / 2));
+    const weaponDamage = this.game.equipmentManager ?
+      this.game.equipmentManager.getWeaponDamage() :
+      (() => {
+        const attackBonus = Math.floor(this.game.playerStats.attack / 2);
+        const variance = Math.floor((Math.random() - 0.5) * attackBonus);
+        return weapon.damage + attackBonus + variance;
+      })();
     
     // Critical hit chance based on luck (5% base + 1% per 5 points of luck)
     const critChance = 0.05 + (Math.floor((this.game.playerStats.luck || 0) / 5) * 0.01);
@@ -313,7 +317,10 @@ export class CombatSystem {
     }
 
     const spell = this.currentSpellList[index];
-    const baseDamage = spell.damage + Math.floor((this.game.playerStats.intelligence || 0) / 2);
+    const intelligence = this.game.playerStats.intelligence || 0;
+    const intBonus = Math.floor(intelligence / 2);
+    const variance = Math.floor((Math.random() - 0.5) * intBonus);
+    const baseDamage = spell.damage + intBonus + variance;
     const critChance = 0.05 + (Math.floor((this.game.playerStats.luck || 0) / 5) * 0.01);
     const isCritical = Math.random() < critChance;
     let damage = baseDamage;

--- a/js/equipmentManager.js
+++ b/js/equipmentManager.js
@@ -101,21 +101,24 @@ export class EquipmentManager {
   }
 
   // Get weapon damage value (with stat bonuses)
-  getWeaponDamage() {
+  getWeaponDamage(includeVariance = true) {
+    const attackStat = this.game.playerStats.attack || 0;
+    const attackBonus = Math.floor(attackStat / 2);
+
+    const variance = includeVariance
+      ? Math.floor((Math.random() - 0.5) * attackBonus)
+      : 0;
+
     if (!this.equipment.weapon) {
-      const defaultWeapon = this.game.weaponManager ? this.game.weaponManager.getWeapon('fists') : { damage: 1 };
-      const attackBonus = Math.floor((this.game.playerStats.attack || 0) / 2);
-      console.log("Default weapon:", defaultWeapon);
-      console.log("Default weapon damage:", defaultWeapon.damage);
-      console.log("Player attack bonus:", attackBonus);
-      return defaultWeapon.damage + attackBonus;
+      const defaultWeapon = this.game.weaponManager
+        ? this.game.weaponManager.getWeapon('fists')
+        : { damage: 1 };
+      const baseDamage = defaultWeapon.damage;
+      return baseDamage + attackBonus + variance;
     }
-  
+
     const baseDamage = this.equipment.weapon.damage || 0;
-    const attackBonus = Math.floor((this.game.playerStats.attack || 0) / 2);
-    console.log("Equipped weapon damage:", baseDamage);
-    console.log("Player attack bonus:", attackBonus);
-    return baseDamage + attackBonus;
+    return baseDamage + attackBonus + variance;
   }
 
   // Get total defense value (with stat bonuses)

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -1001,7 +1001,7 @@ saveGame() {
     let attack = this.game.playerStats.attack || 0;
 
     if (this.game.equipmentManager) {
-      const weaponDamage = this.game.equipmentManager.getWeaponDamage();
+      const weaponDamage = this.game.equipmentManager.getWeaponDamage(false);
       attack = attack + weaponDamage - Math.floor(attack / 2);
     } else {
       const fists = this.game.weaponManager ? this.game.weaponManager.getWeapon('fists') : { damage: 1 };


### PR DESCRIPTION
## Summary
- make weapon damage optionally include randomized variance based on attack
- apply intelligence stat with similar variance when casting spells
- update fallback damage calculations and attack display logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840bf1c10bc83288083e3475aa9502b