### PR TITLE
Fix spell charge warnings

### DIFF
--- a/js/combat.js
+++ b/js/combat.js
@@ -11,10 +11,17 @@ export class CombatSystem {
     this.playerTurn = false;
     this.combatLog = [];
     this.maxPlayerHealth = maxPlayerHealth;
+    this.spellCharges = {};
   }
 
   async initiateCombat(enemy) {
     this.inCombat = true;
+    // Reset spell charges for this combat
+    this.spellCharges = {};
+    (this.game.playerSpells || []).forEach(id => {
+      const s = this.game.spellManager.getSpell(id);
+      if (s) this.spellCharges[id] = s.charges || 1;
+    });
     
     
     // If enemy is a string ID, try to fetch from loot system first
@@ -114,7 +121,9 @@ export class CombatSystem {
   showCombatOptions() {
     this.game.uiManager.clearOutput();
     this.game.uiManager.print("What will you do?", "system-message");
-    this.game.uiManager.print("1. Attack", "combat-option");
+    const weapon = this.getEquippedWeapon();
+    const [minW, maxW] = this.calculateWeaponDamageRange(weapon);
+    this.game.uiManager.print(`1. Attack with ${weapon.name} (${minW}-${maxW} damage)`, "combat-option");
     this.game.uiManager.print("2. Cast Spell", "combat-option");
     this.game.uiManager.print("3. Use Item", "combat-option");
     this.game.uiManager.print("4. Check Enemy", "combat-option");
@@ -142,9 +151,13 @@ export class CombatSystem {
   // Update the playerAttack method to use equipment manager
   playerAttack() {
     const weapon = this.getEquippedWeapon();
-    const weaponDamage = this.game.equipmentManager ? 
-      this.game.equipmentManager.getWeaponDamage() : 
-      (weapon.damage + Math.floor(this.game.playerStats.attack / 2));
+    const weaponDamage = this.game.equipmentManager ?
+      this.game.equipmentManager.getWeaponDamage() :
+      (() => {
+        const attackBonus = Math.floor(this.game.playerStats.attack / 2);
+        const variance = Math.floor((Math.random() - 0.5) * attackBonus);
+        return weapon.damage + attackBonus + variance;
+      })();
     
     // Critical hit chance based on luck (5% base + 1% per 5 points of luck)
     const critChance = 0.05 + (Math.floor((this.game.playerStats.luck || 0) / 5) * 0.01);
@@ -246,7 +259,11 @@ export class CombatSystem {
     
     // Show enemy weapon if available
     if (this.currentEnemy.currentWeapon) {
-      this.game.uiManager.print(`Weapon: ${this.currentEnemy.currentWeapon.name} (${this.currentEnemy.currentWeapon.damage} damage)`, "enemy-stat");
+      const base = this.currentEnemy.currentWeapon.damage;
+      const vrange = Math.floor(base * 0.15);
+      const minE = base - vrange;
+      const maxE = base + vrange;
+      this.game.uiManager.print(`Weapon: ${this.currentEnemy.currentWeapon.name} (${minE}-${maxE} damage)`, "enemy-stat");
     }
     
     this.game.uiManager.print(`${this.currentEnemy.description}\n`, "enemy-description");
@@ -278,8 +295,10 @@ export class CombatSystem {
     this.game.inputMode = "combat-item";
   }
 
-  showSpellList() {
-    this.game.uiManager.clearOutput();
+  showSpellList(skipClear = false) {
+    if (!skipClear) {
+      this.game.uiManager.clearOutput();
+    }
     const knownSpells = (this.game.playerSpells || []).map(id => this.game.spellManager.getSpell(id)).filter(Boolean);
 
     if (knownSpells.length === 0) {
@@ -291,7 +310,9 @@ export class CombatSystem {
     this.currentSpellList = knownSpells;
     this.game.uiManager.print("\nSelect a spell to cast:", "system-message");
     knownSpells.forEach((spell, index) => {
-      this.game.uiManager.print(`${index + 1}. ${spell.name}`, "combat-option");
+      const [minS, maxS] = this.calculateSpellDamageRange(spell);
+      const charges = this.spellCharges[spell.id] ?? spell.charges ?? 1;
+      this.game.uiManager.print(`${index + 1}. ${spell.name} (${minS}-${maxS} damage, ${charges} charges)`, "combat-option");
     });
     this.game.uiManager.print("0. Back to combat options", "combat-option");
     this.game.inputMode = "combat-spell";
@@ -308,12 +329,23 @@ export class CombatSystem {
     const index = parseInt(selection) - 1;
     if (isNaN(index) || !this.currentSpellList || index < 0 || index >= this.currentSpellList.length) {
       this.game.uiManager.print("Invalid spell selection.", "error-message");
-      this.showSpellList();
+      this.showSpellList(true);
       return;
     }
 
     const spell = this.currentSpellList[index];
-    const baseDamage = spell.damage + Math.floor((this.game.playerStats.intelligence || 0) / 2);
+    if (this.spellCharges[spell.id] !== undefined && this.spellCharges[spell.id] <= 0) {
+      this.game.uiManager.print(`${spell.name} has no charges left!`, "system-message");
+      this.showSpellList(true);
+      return;
+    }
+    if (this.spellCharges[spell.id] !== undefined) {
+      this.spellCharges[spell.id]--;
+    }
+    const intelligence = this.game.playerStats.intelligence || 0;
+    const intBonus = Math.floor(intelligence / 2);
+    const variance = Math.floor((Math.random() - 0.5) * intBonus);
+    const baseDamage = spell.damage + intBonus + variance;
     const critChance = 0.05 + (Math.floor((this.game.playerStats.luck || 0) / 5) * 0.01);
     const isCritical = Math.random() < critChance;
     let damage = baseDamage;
@@ -401,6 +433,7 @@ export class CombatSystem {
 
   endCombat(victory) {
     this.inCombat = false;
+    this.spellCharges = {};
     
     if (victory) {
       // Calculate XP reward
@@ -540,6 +573,31 @@ export class CombatSystem {
     }
 
     return { id: 'fists', name: 'Fists', damage: 1 };
+  }
+
+  getVarianceRange(statBonus) {
+    if (statBonus <= 0) return [0, 0];
+    const half = Math.floor(statBonus / 2);
+    if (statBonus % 2 === 0) {
+      return [-half, half - 1];
+    }
+    return [-(half + 1), half];
+  }
+
+  calculateWeaponDamageRange(weapon) {
+    const attackStat = this.game.playerStats.attack || 0;
+    const bonus = Math.floor(attackStat / 2);
+    const [minVar, maxVar] = this.getVarianceRange(bonus);
+    const base = weapon.damage + bonus;
+    return [base + minVar, base + maxVar];
+  }
+
+  calculateSpellDamageRange(spell) {
+    const intStat = this.game.playerStats.intelligence || 0;
+    const bonus = Math.floor(intStat / 2);
+    const [minVar, maxVar] = this.getVarianceRange(bonus);
+    const base = spell.damage + bonus;
+    return [base + minVar, base + maxVar];
   }
 
   getWeapon(id) {

--- a/js/equipmentManager.js
+++ b/js/equipmentManager.js
@@ -101,21 +101,24 @@ export class EquipmentManager {
   }
 
   // Get weapon damage value (with stat bonuses)
-  getWeaponDamage() {
+  getWeaponDamage(includeVariance = true) {
+    const attackStat = this.game.playerStats.attack || 0;
+    const attackBonus = Math.floor(attackStat / 2);
+
+    const variance = includeVariance
+      ? Math.floor((Math.random() - 0.5) * attackBonus)
+      : 0;
+
     if (!this.equipment.weapon) {
-      const defaultWeapon = this.game.weaponManager ? this.game.weaponManager.getWeapon('fists') : { damage: 1 };
-      const attackBonus = Math.floor((this.game.playerStats.attack || 0) / 2);
-      console.log("Default weapon:", defaultWeapon);
-      console.log("Default weapon damage:", defaultWeapon.damage);
-      console.log("Player attack bonus:", attackBonus);
-      return defaultWeapon.damage + attackBonus;
+      const defaultWeapon = this.game.weaponManager
+        ? this.game.weaponManager.getWeapon('fists')
+        : { damage: 1 };
+      const baseDamage = defaultWeapon.damage;
+      return baseDamage + attackBonus + variance;
     }
-  
+
     const baseDamage = this.equipment.weapon.damage || 0;
-    const attackBonus = Math.floor((this.game.playerStats.attack || 0) / 2);
-    console.log("Equipped weapon damage:", baseDamage);
-    console.log("Player attack bonus:", attackBonus);
-    return baseDamage + attackBonus;
+    return baseDamage + attackBonus + variance;
   }
 
   // Get total defense value (with stat bonuses)

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -692,7 +692,12 @@ export class InputHandlers {
       this.game.uiManager.print("Your inventory is empty.", "system-message");
     } else {
       this.game.inventory.forEach((item) => {
-        this.game.uiManager.print(`- ${item.name} ${item.quantity > 1 ? `(x${item.quantity})` : ""}`, "item-name");
+        let label = `- ${item.name}`;
+        if (item.type === "weapon" || item.category === "weapon") {
+          const [minW, maxW] = this.game.combatSystem.calculateWeaponDamageRange(item);
+          label = `- ${item.name} (${minW}-${maxW} damage)`;
+        }
+        this.game.uiManager.print(`${label} ${item.quantity > 1 ? `(x${item.quantity})` : ""}`, "item-name");
         // Show a shorter description in the main inventory view
         if (item.description) {
           const shortDesc = item.description.length > 60 ? 
@@ -964,7 +969,12 @@ saveGame() {
   }
 
   examineItem(item) {
-    this.game.uiManager.print(`\n${item.name}`, "item-name");
+    let header = item.name;
+    if (item.type === "weapon" || item.category === "weapon") {
+      const [minW, maxW] = this.game.combatSystem.calculateWeaponDamageRange(item);
+      header = `${item.name} (${minW}-${maxW} damage)`;
+    }
+    this.game.uiManager.print(`\n${header}`, "item-name");
     
     // Display description if it exists
     if (item.description) {
@@ -1001,7 +1011,7 @@ saveGame() {
     let attack = this.game.playerStats.attack || 0;
 
     if (this.game.equipmentManager) {
-      const weaponDamage = this.game.equipmentManager.getWeaponDamage();
+      const weaponDamage = this.game.equipmentManager.getWeaponDamage(false);
       attack = attack + weaponDamage - Math.floor(attack / 2);
     } else {
       const fists = this.game.weaponManager ? this.game.weaponManager.getWeapon('fists') : { damage: 1 };

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -4,7 +4,8 @@
       "id": "fireball",
       "name": "Fireball",
       "description": "A small ball of fire hurled at your foe.",
-      "damage": 6
+      "damage": 6,
+      "charges": 3
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add optional skipClear flag to `showSpellList`
- preserve warning messages for no spell charges

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840bf1c10bc83288083e3475aa9502b