### PR TITLE
Add quest loot and items for early chapters

### DIFF
--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -18,10 +18,11 @@ export class GameLogic {
         await this.game.typeText(scene.text);
       }
 
-      if (scene.items) {
-        this.addItemsToInventory(scene.items);
+      const lootItems = scene.items || scene.loot;
+      if (lootItems) {
+        this.addItemsToInventory(lootItems);
         this.game.uiManager.print("\nAcquired items:", "system-message");
-        scene.items.forEach((item) => {
+        lootItems.forEach((item) => {
           this.game.uiManager.print(`- ${item.name} ${item.quantity > 1 ? `(x${item.quantity})` : ""}`, "item-name");
         });
         this.game.uiManager.print("", ""); // Add a blank line

--- a/story/chapters/chapter1.json
+++ b/story/chapters/chapter1.json
@@ -2,6 +2,14 @@
   "scenes": {
     "intro": {
       "text": "The village of Frostpeak sits nestled between snow-capped mountains, normally peaceful and quiet. But not today. Today, smoke rises from burned homes, and grief hangs heavy in the air.\n\nYou are Olaf, son of Bjorn the Mighty, the village's respected chieftain and most fearsome warrior. Or at least, he was until yesterday's dawn when the bears came.\n\nNot ordinary bears - these walked on two legs like men, wielded crude weapons, and worst of all, they seemed to communicate and coordinate their attack with terrifying intelligence.\n\nYou kneel beside your father's body as the village prepares for the funeral rites. His mighty axe 'Winterbite' lies broken beside him, having claimed several bear warriors before he fell.\n\n\"I will avenge you, father,\" you whisper, taking the leather necklace from his neck - a family heirloom carved with ancient runes.",
+      "loot": [
+        {
+          "id": "fathers_necklace",
+          "name": "Father's Necklace",
+          "category": "quest",
+          "description": "An heirloom passed down from Bjorn, now yours."
+        }
+      ],
       "nextScene": "village_gathering"
     },
     "village_gathering": {
@@ -53,10 +61,28 @@
     },
     "preparation_investigation": {
       "text": "\"We can't fight what we don't understand,\" you say thoughtfully. \"There must be a reason for this change in the bears. If we discover the cause, perhaps we can stop it.\"\n\nElder Hulda smiles faintly. \"Wisdom beyond your years, Olaf. Your mother would be proud.\"\n\nSigrid the Sage, an old woman who lives at the edge of the village, speaks up. \"The bears' transformation is unnatural. In my scrolls, there are tales of ancient magics that can twist beasts into something more. I can help you understand what we're facing.\"\n\nMagnus scoffs. \"Scrolls won't stop bear claws, old woman.\"\n\n\"But they might tell us where to look,\" you counter. \"I'll need both knowledge and strength for this journey.\"\n\nKarina joins the conversation. \"The western traders spoke of a hermit living in the mountains who studies the wild creatures. He might know something about these bears.\"\n\nThrain approaches with a sturdy shield. \"Knowledge is well and good, but take this too. It was your father's when he was younger - light enough to carry on a long journey, strong enough to stop a bear's swing.\"",
+      "loot": [
+        {
+          "id": "sturdy_shield",
+          "name": "Sturdy Shield",
+          "category": "armor",
+          "defense": 3,
+          "description": "A reliable shield once used by your father."
+        }
+      ],
       "nextScene": "departure_choices"
     },
     "preparation_defense": {
       "text": "\"Our first duty must be to protect what remains,\" you declare. \"We should fortify the village before they return.\"\n\nThrain nods approvingly. \"Wise choice. I've been thinking about how to strengthen our defenses. With enough hands, we could build a palisade within a week.\"\n\nSome of the villagers look relieved, while others seem disappointed that immediate vengeance isn't forthcoming.\n\nMagnus crosses his arms. \"And while we're building, the bears grow stronger. We need to strike them now, before they organize another attack.\"\n\n\"We can do both,\" you suggest. \"Begin the fortifications while a small group investigates the threat.\"\n\nElder Hulda considers. \"A compromise, then. Thrain will oversee our defenses here. Olaf, you'll lead a scouting party to assess the bears' numbers and locations before we plan our next move.\"\n\nKarina steps forward. \"I know which herbs can help heal wounds quickly. I'll help with the scouting party.\"\n\nThrain hands you a finely crafted spear. \"This will give you reach against those beasts. Return to us with information, Olaf. And may your father's spirit guide your arm.\"",
+      "loot": [
+        {
+          "id": "crafted_spear",
+          "name": "Finely Crafted Spear",
+          "category": "weapon",
+          "damage": 9,
+          "description": "A spear from Thrain's forge, balanced and deadly."
+        }
+      ],
       "nextScene": "departure_choices"
     },
     "departure_choices": {
@@ -587,6 +613,15 @@
     },
     "hermit_path_from_village": {
       "text": "After the council meeting, you prepare for the journey to the hermit's cave. Thrain provides you with a better weapon - a finely crafted battle axe that feels perfectly balanced in your hands.\n\n\"This should serve you better than that old hunting knife,\" he says gruffly.\n\nKarina joins you, her medical pouch restocked with fresh herbs and bandages. Two other volunteers step forward as well: Leif, a young but skilled archer, and Tormund, a veteran warrior who once fought alongside your father.\n\n\"Four will move faster than an army,\" Tormund says, \"but still give us a fighting chance if we encounter trouble.\"\n\nElder Hulda sees you off at the newly constructed gate. \"Find the hermit, learn what you can, but don't take unnecessary risks. The village needs you alive, Olaf.\"\n\nThe journey to the western mountains takes you through terrain that grows increasingly wild and untamed. By nightfall on the first day, you've reached the foothills, where you make camp in a defensible position between two large boulders.\n\nAs you sit around a small, carefully shielded fire, Tormund speaks of his memories of your father.\n\n\"Bjorn wasn't just strong,\" he tells you. \"He was clever. Always thinking three steps ahead. That's why the bears targeted him first - they knew he'd see through their plans, organize a proper defense.\"",
+      "loot": [
+        {
+          "id": "battle_axe",
+          "name": "Battle Axe",
+          "category": "weapon",
+          "damage": 12,
+          "description": "A battle axe from Thrain, meant for serious combat."
+        }
+      ],
       "nextScene": "night_attack_camp"
     },
     "night_attack_camp": {

--- a/story/chapters/chapter2.json
+++ b/story/chapters/chapter2.json
@@ -4,14 +4,21 @@
       "text": "Three months have passed since the battle at the stone circle. Frostpeak has flourished under your leadership, its walls strengthened, its warriors better trained. The surviving bears have returned to their natural behavior, once again mere animals in the forest.\n\nYet peace remains fragile. Rumors spread of strange figures seen in the mountains, and hunters report finding complex symbols carved into ancient trees. The Wild Court that Lyra warned about may have already sent agents to continue their work.\n\nOn a crisp autumn morning, as you oversee training exercises with Magnus, a sentry's horn sounds from the watchtower. A lone rider approaches at breakneck speed, their cloak billowing behind them.",
       "nextScene": "lyra_returns"
     },
-    
     "lyra_returns": {
       "text": "The gates swing open to admit the rider. As they dismount, you recognize Lyra, the scholar from the Eastern Realms. Her clothes are travel-worn and splattered with blood - not her own, you hope. Her expression is grim as she approaches.\n\n\"They're coming,\" she says without preamble. \"The Wild Court has sent their Beastmaster.\"\n\n\"Inside,\" you reply, gesturing toward the council hall. \"Tell me everything.\"\n\nOnce gathered with your advisors - Karina, Magnus, Thrain, and Elder Hulda - Lyra unrolls a map across the table.\n\n\"The Wild Court was furious when they learned of their ritual's failure,\" she explains. \"They've dispatched Vargoth, their most dangerous agent. He doesn't need the stone circle or the orb - he has other methods of transformation, cruder but effective.\"\n\n\"What exactly is a Beastmaster?\" Thrain asks, frowning.\n\nLyra's expression darkens. \"He binds animals to his will through blood magic. Where the spirit could only influence bears, Vargoth can control multiple species simultaneously - wolves, boars, even birds of prey. And he doesn't just make them intelligent; he warps them, twists their bodies into unnatural forms.\"\n\n\"Where is he now?\" you ask.\n\n\"He's established a lair in the ruins of Blackcrag Keep,\" Lyra points to a location in the mountains west of Wispwood. \"My order has been tracking his movements. He's been capturing wild animals and... changing them. Building an army.\"",
       "nextScene": "council_discussion"
     },
-    
     "council_discussion": {
       "text": "\"An army of twisted beasts,\" Magnus mutters. \"Just what we need.\"\n\n\"How long do we have?\" you ask.\n\n\"Days, perhaps a week,\" Lyra replies. \"He's waiting for something - a celestial alignment my order believes will enhance his power.\"\n\nElder Hulda speaks up. \"We should warn the other villages immediately.\"\n\n\"I agree,\" you say. \"But we also need to take the fight to him. If he's still gathering his forces, we might have a chance to stop this before it begins.\"\n\n\"Blackcrag Keep is treacherous ground,\" Thrain cautions. \"Ancient ruins, unstable. Many passages and chambers where ambushes could be set.\"\n\n\"And we don't know what kinds of creatures he's created,\" Karina adds. \"We'd be facing unknown threats.\"\n\nLyra nods grimly. \"I've brought something that might help.\" She produces a small, ornate box from her pack and opens it to reveal several vials of shimmering blue liquid. \"Elixir of Clarity. It temporarily allows one to see through magical disguises and illusions. Essential when fighting a Beastmaster's creations.\"\n\nYou consider the options before you. Time is short, and the threat is grave.",
+      "loot": [
+        {
+          "id": "elixir_clarity",
+          "name": "Elixir of Clarity",
+          "category": "consumable",
+          "quantity": 2,
+          "description": "A potion that reveals illusions and hidden magic."
+        }
+      ],
       "choices": [
         {
           "text": "\"We assault Blackcrag Keep immediately with our best warriors.\"",
@@ -27,15 +34,31 @@
         }
       ]
     },
-    
     "prepare_assault": {
       "text": "\"We strike now, while we still have the element of surprise,\" you decide. \"If we wait, his forces will only grow stronger.\"\n\nThrain pounds the table in agreement. \"Good! I'd rather die on my feet in battle than wait to be torn apart by monsters.\"\n\nYou spend the rest of the day preparing your assault force. Twenty of your best warriors volunteer, including Karina, who insists her healing skills will be needed. Lyra will guide you to the keep and help counter Vargoth's magic.\n\nAs dusk approaches, Magnus returns from the armory with a heavily wrapped bundle. \"This was your father's,\" he says, unveiling Winterbite, your father's great axe. \"We reforged the blade. It's time it was wielded again.\"\n\nYou take the weapon, feeling its perfect balance despite its size. \"Thank you, Magnus.\"\n\nWith final preparations complete, you address your warriors. \"We leave at first light. What we face may be unlike anything we've encountered before. But remember - regardless of how these creatures appear, they were once normal animals, twisted by dark magic. They can be killed like any other beast.\"\n\nThat night, unable to sleep, you visit the village shrine to pay respects to your father's memory. As you kneel before the ceremonial flame, you hear soft footsteps behind you.",
+      "loot": [
+        {
+          "id": "winterbite_axe",
+          "name": "Reforged Winterbite",
+          "category": "weapon",
+          "damage": 15,
+          "description": "Your father\"s great axe, reforged for battle."
+        }
+      ],
       "nextScene": "night_visitor"
     },
-    
     "reconnaissance_mission": {
       "text": "\"We need more information before committing to a full assault,\" you announce. \"I'll lead a small team to scout Blackcrag Keep, assess Vargoth's forces, and find potential weaknesses.\"\n\n\"A wise choice,\" Lyra approves. \"Beastmasters are cunning. Rushing in blindly would play into his hands.\"\n\nYou select four companions for the mission: Leif for his archery and tracking skills, Karina for healing, Lyra for her knowledge of the Wild Court, and Tormund for his experience and fighting prowess.\n\nAs you gather supplies, Magnus approaches with a small wooden case. \"Take these,\" he says, opening it to reveal several small, intricately carved stones. \"Whisper stones. Speak into one, and those holding the others will hear you, no matter the distance. My grandfather traded with eastern merchants for them years ago.\"\n\n\"Perfect for coordinating once we're inside the keep,\" you note, distributing the stones among your team.\n\nWith night falling, you set out under cover of darkness, following game trails through the mountains. The journey is arduous, and twice you encounter strange tracks unlike any animal you recognize - massive clawed prints with an unnatural gait.\n\nBy dawn, you've reached a ridge overlooking Blackcrag Keep. The ancient fortress, built into the mountainside, is partially collapsed but still imposing. Smoke rises from several locations within its walls, and movement can be seen along the battlements - creatures patrolling on all fours, but with unnaturally elongated limbs and misshapen heads.",
-      "nextScene": "observing_blackcrag"
+      "nextScene": "observing_blackcrag",
+      "loot": [
+        {
+          "id": "whisper_stone",
+          "name": "Whisper Stone",
+          "category": "quest",
+          "quantity": 4,
+          "description": "Magically linked stones for silent communication."
+        }
+      ]
     }
   }
 }

--- a/weapons/weapons.json
+++ b/weapons/weapons.json
@@ -85,5 +85,42 @@
       "usable": false,
       "equipable": true
     }
+    ,
+    {
+      "id": "sturdy_shield",
+      "name": "Sturdy Shield",
+      "description": "A well-balanced shield passed down from Olaf's father.",
+      "type": "armor",
+      "defense": 3,
+      "strengthRequirement": 2,
+      "sellValue": 10,
+      "stackable": false,
+      "usable": false,
+      "equipable": true
+    },
+    {
+      "id": "crafted_spear",
+      "name": "Finely Crafted Spear",
+      "description": "A spear crafted by Thrain, offering good reach.",
+      "type": "weapon",
+      "damage": 9,
+      "strengthRequirement": 4,
+      "sellValue": 12,
+      "stackable": false,
+      "usable": false,
+      "equipable": true
+    },
+    {
+      "id": "winterbite_axe",
+      "name": "Winterbite",
+      "description": "Your father's great axe, reforged to its former glory.",
+      "type": "weapon",
+      "damage": 15,
+      "strengthRequirement": 6,
+      "sellValue": 50,
+      "stackable": false,
+      "usable": false,
+      "equipable": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- grant Father’s Necklace in the intro scene
- provide shield, spear and battle axe rewards in chapter 1 scenes
- give reforged Winterbite, whisper stones and Lyra’s elixir in chapter 2 scenes
- extend `GameLogic` to accept `loot` or `items` fields
- define new equipment in weapons data

## Testing
- `node -e "require('./game.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca28c5688328adafcf1235556d15