### PR TITLE
Add loot drops for chapter2 items

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -1,0 +1,24 @@
+{
+  "items": [
+    {
+      "id": "elixir_clarity",
+      "name": "Elixir of Clarity",
+      "description": "A shimmering blue liquid that reveals magical disguises.",
+      "category": "consumable",
+      "stackable": true,
+      "usable": true,
+      "effects": {
+        "reveal_illusions": true,
+        "duration": "scene"
+      }
+    },
+    {
+      "id": "whisper_stone",
+      "name": "Whisper Stone",
+      "description": "Magically linked stones that allow distant communication.",
+      "category": "quest",
+      "stackable": false,
+      "usable": false
+    }
+  ]
+}

--- a/js/combat.js
+++ b/js/combat.js
@@ -127,6 +127,7 @@ export class CombatSystem {
     this.game.uiManager.print("2. Cast Spell", "combat-option");
     this.game.uiManager.print("3. Use Item", "combat-option");
     this.game.uiManager.print("4. Check Enemy", "combat-option");
+    this.game.uiManager.print("5. Inventory / Equip", "combat-option");
   }
 
   processPlayerAction(action) {
@@ -142,6 +143,10 @@ export class CombatSystem {
       this.showInventory();
     } else if (actionLower === "4" || actionLower === "check enemy") {
       this.checkEnemy();
+    } else if (actionLower === "5" || actionLower === "inventory" || actionLower === "equip" || actionLower === "equipment") {
+      if (this.game.inputHandlers && typeof this.game.inputHandlers.showInventory === 'function') {
+        this.game.inputHandlers.showInventory();
+      }
     } else {
       this.game.uiManager.print("Invalid combat action. Try again.", "error-message");
       this.showCombatOptions();

--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -18,10 +18,11 @@ export class GameLogic {
         await this.game.typeText(scene.text);
       }
 
-      if (scene.items) {
-        this.addItemsToInventory(scene.items);
+      if (scene.items || scene.loot) {
+        const gained = scene.items || scene.loot;
+        this.addItemsToInventory(gained);
         this.game.uiManager.print("\nAcquired items:", "system-message");
-        scene.items.forEach((item) => {
+        gained.forEach((item) => {
           this.game.uiManager.print(`- ${item.name} ${item.quantity > 1 ? `(x${item.quantity})` : ""}`, "item-name");
         });
         this.game.uiManager.print("", ""); // Add a blank line

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -679,11 +679,16 @@ export class InputHandlers {
     this.game.uiManager.clearOutput();
     if (this.game.inputMode === "normal") {
       this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
     }
   }
 
   showInventory() {
-    this.game.previousMode = this.game.inputMode;
+    // Preserve the original mode when opening inventory the first time
+    if (this.game.inputMode !== "inventory") {
+      this.game.previousMode = this.game.inputMode;
+    }
     this.game.inputMode = "inventory";
     this.game.uiManager.clearOutput();
     this.game.uiManager.print("===== INVENTORY =====", "system-message");
@@ -1263,6 +1268,8 @@ saveGame() {
     this.game.uiManager.clearOutput();
     if (this.game.inputMode === "normal") {
       this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
     }
   }
 }

--- a/story/chapters/chapter2.json
+++ b/story/chapters/chapter2.json
@@ -12,6 +12,19 @@
     
     "council_discussion": {
       "text": "\"An army of twisted beasts,\" Magnus mutters. \"Just what we need.\"\n\n\"How long do we have?\" you ask.\n\n\"Days, perhaps a week,\" Lyra replies. \"He's waiting for something - a celestial alignment my order believes will enhance his power.\"\n\nElder Hulda speaks up. \"We should warn the other villages immediately.\"\n\n\"I agree,\" you say. \"But we also need to take the fight to him. If he's still gathering his forces, we might have a chance to stop this before it begins.\"\n\n\"Blackcrag Keep is treacherous ground,\" Thrain cautions. \"Ancient ruins, unstable. Many passages and chambers where ambushes could be set.\"\n\n\"And we don't know what kinds of creatures he's created,\" Karina adds. \"We'd be facing unknown threats.\"\n\nLyra nods grimly. \"I've brought something that might help.\" She produces a small, ornate box from her pack and opens it to reveal several vials of shimmering blue liquid. \"Elixir of Clarity. It temporarily allows one to see through magical disguises and illusions. Essential when fighting a Beastmaster's creations.\"\n\nYou consider the options before you. Time is short, and the threat is grave.",
+      "loot": [
+        {
+          "id": "elixir_clarity",
+          "name": "Elixir of Clarity",
+          "category": "consumable",
+          "quantity": 3,
+          "description": "A shimmering blue liquid that reveals magical disguises.",
+          "effects": {
+            "reveal_illusions": true,
+            "duration": "scene"
+          }
+        }
+      ],
       "choices": [
         {
           "text": "\"We assault Blackcrag Keep immediately with our best warriors.\"",
@@ -30,11 +43,29 @@
     
     "prepare_assault": {
       "text": "\"We strike now, while we still have the element of surprise,\" you decide. \"If we wait, his forces will only grow stronger.\"\n\nThrain pounds the table in agreement. \"Good! I'd rather die on my feet in battle than wait to be torn apart by monsters.\"\n\nYou spend the rest of the day preparing your assault force. Twenty of your best warriors volunteer, including Karina, who insists her healing skills will be needed. Lyra will guide you to the keep and help counter Vargoth's magic.\n\nAs dusk approaches, Magnus returns from the armory with a heavily wrapped bundle. \"This was your father's,\" he says, unveiling Winterbite, your father's great axe. \"We reforged the blade. It's time it was wielded again.\"\n\nYou take the weapon, feeling its perfect balance despite its size. \"Thank you, Magnus.\"\n\nWith final preparations complete, you address your warriors. \"We leave at first light. What we face may be unlike anything we've encountered before. But remember - regardless of how these creatures appear, they were once normal animals, twisted by dark magic. They can be killed like any other beast.\"\n\nThat night, unable to sleep, you visit the village shrine to pay respects to your father's memory. As you kneel before the ceremonial flame, you hear soft footsteps behind you.",
+      "loot": [
+        {
+          "id": "winterbite",
+          "name": "Winterbite",
+          "category": "weapon",
+          "damage": 15,
+          "description": "Your father's reforged great axe."
+        }
+      ],
       "nextScene": "night_visitor"
     },
     
     "reconnaissance_mission": {
       "text": "\"We need more information before committing to a full assault,\" you announce. \"I'll lead a small team to scout Blackcrag Keep, assess Vargoth's forces, and find potential weaknesses.\"\n\n\"A wise choice,\" Lyra approves. \"Beastmasters are cunning. Rushing in blindly would play into his hands.\"\n\nYou select four companions for the mission: Leif for his archery and tracking skills, Karina for healing, Lyra for her knowledge of the Wild Court, and Tormund for his experience and fighting prowess.\n\nAs you gather supplies, Magnus approaches with a small wooden case. \"Take these,\" he says, opening it to reveal several small, intricately carved stones. \"Whisper stones. Speak into one, and those holding the others will hear you, no matter the distance. My grandfather traded with eastern merchants for them years ago.\"\n\n\"Perfect for coordinating once we're inside the keep,\" you note, distributing the stones among your team.\n\nWith night falling, you set out under cover of darkness, following game trails through the mountains. The journey is arduous, and twice you encounter strange tracks unlike any animal you recognize - massive clawed prints with an unnatural gait.\n\nBy dawn, you've reached a ridge overlooking Blackcrag Keep. The ancient fortress, built into the mountainside, is partially collapsed but still imposing. Smoke rises from several locations within its walls, and movement can be seen along the battlements - creatures patrolling on all fours, but with unnaturally elongated limbs and misshapen heads.",
+      "loot": [
+        {
+          "id": "whisper_stone",
+          "name": "Whisper Stone",
+          "category": "quest",
+          "quantity": 4,
+          "description": "Magically linked stones that allow distant communication."
+        }
+      ],
       "nextScene": "observing_blackcrag"
     }
   }

--- a/weapons/weapons.json
+++ b/weapons/weapons.json
@@ -84,6 +84,18 @@
       "stackable": false,
       "usable": false,
       "equipable": true
+    },
+    {
+      "id": "winterbite",
+      "name": "Winterbite",
+      "description": "Your father's legendary great axe reforged for battle.",
+      "type": "weapon",
+      "damage": 15,
+      "strengthRequirement": 8,
+      "sellValue": 50,
+      "stackable": false,
+      "usable": false,
+      "equipable": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- give the player Elixir of Clarity during the council discussion
- award Winterbite in `prepare_assault`
- provide Whisper Stones in `reconnaissance_mission`
- define Winterbite weapon
- preserve original mode when opening inventory so `back` resumes correctly

## Testing
- `node --check js/combat.js`
- `node --check js/inputHandlers.js`
- `node --check js/gameLogic.js`
- `jq . items/items.json > /dev/null && echo OK`
- `jq . story/chapters/chapter2.json > /dev/null && echo OK`
- `jq . weapons/weapons.json > /dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_6840ca298330832898438531bdb68b37