### PR TITLE
Replace combat timers with manual continue input

### DIFF
--- a/game.js
+++ b/game.js
@@ -61,6 +61,7 @@ class TextGame {
     this.awaitingInput = false;
     this.inputMode = "normal";
     this.previousMode = null;
+    this.continueCallback = null;
     this.isLoading = false;
     this.gameOutput = document.getElementById("gameOutput");
     this.gameInput = document.getElementById("gameInput");

--- a/js/combat.js
+++ b/js/combat.js
@@ -1,4 +1,4 @@
-import { maxPlayerHealth, xpPerLevel, combatDelay } from './constants.js';
+import { maxPlayerHealth, xpPerLevel } from './constants.js';
 import { WeaponManager } from './weaponManager.js';
 
 const weaponManager = new WeaponManager();
@@ -103,14 +103,17 @@ export class CombatSystem {
     // Show enemy and player stats
     this.displayCombatStatus();
     
-    // If enemy goes first, process their turn
-    if (!this.playerTurn) {
-      setTimeout(() => this.processEnemyTurn(), combatDelay);
-    } else {
-      setTimeout(() => this.showCombatOptions(), combatDelay);
-    }
-    
-    this.game.inputMode = "combat";
+    // Prompt to begin the first turn
+    this.game.uiManager.print("\nType 'continue' to begin combat...", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
+      if (!this.playerTurn) {
+        this.processEnemyTurn();
+      } else {
+        this.showCombatOptions();
+      }
+    };
   }
 
   displayCombatStatus() {
@@ -197,9 +200,14 @@ export class CombatSystem {
       return;
     }
     
-    // Set up enemy turn after a delay
+    // Wait for player to continue before enemy turn
     this.playerTurn = false;
-    setTimeout(() => this.processEnemyTurn(), combatDelay);
+    this.game.uiManager.print("\nType 'continue' for the enemy's turn.", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
+      this.processEnemyTurn();
+    };
   }
 
   processEnemyTurn() {
@@ -246,12 +254,15 @@ export class CombatSystem {
       return;
     }
     
-    // End enemy turn
+    // Wait for player to continue back to their turn
     this.playerTurn = true;
-    setTimeout(() => {
+    this.game.uiManager.print("\nType 'continue' for your turn.", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
       this.displayCombatStatus();
       this.showCombatOptions();
-    }, combatDelay);
+    };
   }
 
   checkEnemy() {
@@ -273,10 +284,13 @@ export class CombatSystem {
     
     this.game.uiManager.print(`${this.currentEnemy.description}\n`, "enemy-description");
     
-    // Return to combat options after a short delay
-    setTimeout(() => {
+    // Wait for player to continue back to combat options
+    this.game.uiManager.print("Type 'continue' to resume combat.", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
       this.showCombatOptions();
-    }, combatDelay);
+    };
   }
 
   showInventory() {
@@ -376,8 +390,12 @@ export class CombatSystem {
     }
 
     this.playerTurn = false;
-    this.game.inputMode = "combat";
-    setTimeout(() => this.processEnemyTurn(), combatDelay);
+    this.game.uiManager.print("\nType 'continue' for the enemy's turn.", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
+      this.processEnemyTurn();
+    };
   }
 
   useItem(itemIndex) {
@@ -406,10 +424,12 @@ export class CombatSystem {
     
     // End player turn after using an item
     this.playerTurn = false;
-    this.game.inputMode = "combat";
-    
-    // Enemy turn after delay
-    setTimeout(() => this.processEnemyTurn(), combatDelay);
+    this.game.uiManager.print("\nType 'continue' for the enemy's turn.", "system-message");
+    this.game.inputMode = "await-continue";
+    this.game.continueCallback = () => {
+      this.game.inputMode = "combat";
+      this.processEnemyTurn();
+    };
   }
 
   applyItemEffect(item) {
@@ -479,23 +499,27 @@ export class CombatSystem {
         });
       }
       
-      // Continue to next scene
-      setTimeout(() => {
+      // Prompt player to continue to the next scene
+      this.game.uiManager.print("\nType 'continue' to proceed.", "system-message");
+      this.game.inputMode = "await-continue";
+      this.game.continueCallback = () => {
         this.game.currentScene = this.game.nextSceneAfterCombat;
         this.game.inputMode = "normal";
         this.game.playScene();
-      }, 3000);
+      };
     } else {
       // Player defeated
       this.game.uiManager.print("\nYou have been defeated!", "defeat-message");
-      
-      // Continue to defeat scene if specified
-      setTimeout(() => {
+
+      // Prompt player to continue to defeat scene if specified
+      this.game.uiManager.print("Type 'continue' to proceed.", "system-message");
+      this.game.inputMode = "await-continue";
+      this.game.continueCallback = () => {
         this.game.currentScene = this.game.defeatSceneAfterCombat;
         this.game.inputMode = "normal";
         this.game.gameState.playerHealth = this.maxPlayerHealth; // Reset health on defeat
         this.game.playScene();
-      }, 3000);
+      };
     }
   }
 

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -914,12 +914,18 @@ saveGame() {
       return;
     }
     
-    // For the continue command, load the stored next scene and resume gameplay
+    // For the continue command, either trigger a callback or load the next scene
     if (input === "continue" || input === "c") {
-      this.game.currentScene = this.game.nextSceneToLoad;
-      this.game.nextSceneToLoad = null;
-      this.game.inputMode = "normal";
-      this.game.gameLogic.playScene();
+      if (this.game.continueCallback) {
+        const cb = this.game.continueCallback;
+        this.game.continueCallback = null;
+        cb();
+      } else {
+        this.game.currentScene = this.game.nextSceneToLoad;
+        this.game.nextSceneToLoad = null;
+        this.game.inputMode = "normal";
+        this.game.gameLogic.playScene();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- require manual `continue`/`c` input between combat turns
- support callbacks for `await-continue` state
- add helper to TextGame for these callbacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e73bc1d88328ad67eec76df13cf6