### PR TITLE
Add new Olaf vs bears loading quips

### DIFF
--- a/loadingQuips.json
+++ b/loadingQuips.json
@@ -9,6 +9,16 @@
     "Loading... Just bear with us, Olaf is on his way.",
     "Loading... This won't take long.",
     "Loading... Patience is a virtue.",
-    "Loading... Good things come to those who wait."
+    "Loading... Good things come to those who wait.",
+    "Loading... Checking Olaf's axe for sharpness.",
+    "Loading... Thrain is forging something special.",
+    "Loading... Karina insists you stretch first.",
+    "Loading... The road to Wispwood is icy today.",
+    "Loading... Listening for bear growls in the distance.",
+    "Loading... The hermit's still scribbling cryptic notes.",
+    "Loading... Olaf's beard is almost battle-ready.",
+    "Loading... Restringing your bow just in case.",
+    "Loading... Sharpening arrows for that perfect shot.",
+    "Loading... Ready your wits and your weapons."
   ]
 }


### PR DESCRIPTION
## Summary
- enrich loading screen humor by adding ten new quips
- keep quips relevant to Olaf, bears and the world of Wispwood

## Testing
- `jq '.' loadingQuips.json`

------
https://chatgpt.com/codex/tasks/task_e_6841187a31608328817bd141ca44049c