### PR TITLE
Add talent system

### DIFF
--- a/game.js
+++ b/game.js
@@ -317,55 +317,8 @@ class TextGame {
   }
 
   handleInput() {
-    if (this.isTyping) return;
-    const rawInput = this.gameInput.value.trim();
-    this.uiManager.clearInput();
-    this.uiManager.print(`> ${rawInput}`, "player-input");
-    const input = this.inputMode === "loadGame" ? rawInput : rawInput.toLowerCase();
-    
-    switch (this.inputMode) {
-      case "title":
-        this.inputHandlers.handleTitleInput(input);
-        break;
-      case "normal":
-        this.inputHandlers.handleNormalInput(input);
-        break;
-      case "choices":
-        this.inputHandlers.handleChoiceInput(input);
-        break;
-      case "stats":
-        this.inputHandlers.handleStatInput(input);
-        break;
-      case "inventory":
-        this.inputHandlers.handleInventoryInput(input);
-        break;
-      case "loadGame":
-        this.inputHandlers.handleLoadGameInput(rawInput);
-        break;
-      case "errorRecovery":
-        this.inputHandlers.handleErrorRecoveryInput(input);
-        break;
-      case "combat":
-        this.inputHandlers.handleCombatInput(input);
-        break;
-      case "await-continue":
-        this.inputHandlers.handleAwaitContinueInput(input);
-        break;
-      case "await-combat":
-        this.inputHandlers.handleAwaitCombatInput(input);
-        break;
-      case "combat-item":
-        this.inputHandlers.handleCombatItemInput(input);
-        break;
-      case "combat-spell":
-        this.inputHandlers.handleCombatSpellInput(input);
-        break;
-      case "equipment":
-        this.inputHandlers.handleEquipmentInput(input);
-        break;
-      case "equip-confirm":
-        // This is handled by the equipItem method
-        break;
+    if (this.inputHandlers && typeof this.inputHandlers.handleInput === 'function') {
+      this.inputHandlers.handleInput();
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -55,6 +55,14 @@
       </div>
       <div id="equipment-content" class="panel-content"></div>
     </div>
+
+    <div id="talent-panel" class="talent-panel ui-panel hidden">
+      <div class="panel-header">
+        <h2>Talents</h2>
+        <button id="close-talent" class="close-button">×</button>
+      </div>
+      <div id="talent-content" class="panel-content"></div>
+    </div>
     
     <script type="module" src="game.js"></script>
   </body>

--- a/js/combat.js
+++ b/js/combat.js
@@ -552,11 +552,18 @@ export class CombatSystem {
         this.game.gameState.availableStatPoints = 0;
       }
       this.game.gameState.availableStatPoints += levelsGained;
+
+      if (!this.game.gameState.talentPoints) {
+        this.game.gameState.talentPoints = 0;
+      }
+      this.game.gameState.talentPoints += levelsGained;
       
       // Display level up message
       this.game.uiManager.print(`\nLevel up! You are now level ${newLevel}!`, "level-up");
       this.game.uiManager.print(`You gained ${levelsGained} stat point(s)!`, "stat-points");
       this.game.uiManager.print(`Type 'stats' anytime to allocate your points.`, "system-message");
+      this.game.uiManager.print(`You gained ${levelsGained} talent point(s)!`, "stat-points");
+      this.game.uiManager.print(`Type 'talents' to view the talent tree.`, "system-message");
     }
   }
 

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -683,7 +683,7 @@ export class InputHandlers {
     this.game.inputMode = this.game.previousMode || "normal";
     this.game.previousMode = null;
     this.game.uiManager.clearOutput();
-    if (this.game.inputMode === "normal") {
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
       this.game.gameLogic.playScene();
     } else if (this.game.inputMode === "combat") {
       this.game.combatSystem.showCombatOptions();
@@ -1281,7 +1281,7 @@ saveGame() {
     
     // Clear output and return to game if needed
     this.game.uiManager.clearOutput();
-    if (this.game.inputMode === "normal") {
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
       this.game.gameLogic.playScene();
     } else if (this.game.inputMode === "combat") {
       this.game.combatSystem.showCombatOptions();
@@ -1297,7 +1297,7 @@ saveGame() {
     this.game.previousMode = null;
 
     this.game.uiManager.clearOutput();
-    if (this.game.inputMode === "normal") {
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
       this.game.gameLogic.playScene();
     } else if (this.game.inputMode === "combat") {
       this.game.combatSystem.showCombatOptions();

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -14,13 +14,13 @@ export class InputHandlers {
       this.game.toggleNotes();
       return;
     }
-    
+
     // Add map command check
     if (input === "map" || input === "m") {
       this.game.toggleMap();
       return;
     }
-    
+
     // Then continue with existing combat input handling
     this.game.combatSystem.processPlayerAction(input);
   }
@@ -38,7 +38,7 @@ export class InputHandlers {
       this.game.toggleMap();
       return;
     }
-    
+
     // Then continue with existing combat item input handling
     this.game.combatSystem.useItem(input);
   }
@@ -90,6 +90,11 @@ export class InputHandlers {
     // Add global map command check
     if (input === "map" || input === "m") {
       this.game.toggleMap();
+      return;
+    }
+
+    if (input === "talents" || input === "skills" || input === "talent") {
+      this.game.toggleTalents();
       return;
     }
 
@@ -557,6 +562,10 @@ export class InputHandlers {
       this.game.gameState.playerHealth = this.game.initialPlayerHealth;
       this.game.gameState.playerXp = this.game.initialPlayerXp;
       this.game.gameState.availableStatPoints = 0;
+      this.game.gameState.talentPoints = 0;
+      if (this.game.talentManager) {
+        this.game.talentManager.acquired = [];
+      }
     });
 
     this.game.inputMode = "stats";
@@ -639,6 +648,7 @@ export class InputHandlers {
     this.game.uiManager.print("equipment, equip - Show your equipped items", "help-text");
     this.game.uiManager.print("notes, note - Open/close the notes panel", "help-text");
     this.game.uiManager.print("map, m - Open/close the map", "help-text");
+    this.game.uiManager.print("talents, skills - Open the talent tree", "help-text");
     this.game.uiManager.print("save - Save your game", "help-text");
     this.game.uiManager.print("load - Load a saved game", "help-text");
     this.game.uiManager.print("quit, exit, title - Return to title screen", "help-text");
@@ -1270,6 +1280,22 @@ saveGame() {
     console.log("Restored input mode to:", this.game.inputMode);
     
     // Clear output and return to game if needed
+    this.game.uiManager.clearOutput();
+    if (this.game.inputMode === "normal") {
+      this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
+    }
+  }
+
+  resumeAfterTalent() {
+    if (this.game.talentTreeUI) {
+      this.game.talentTreeUI.toggle(false);
+    }
+
+    this.game.inputMode = this.game.previousMode || "normal";
+    this.game.previousMode = null;
+
     this.game.uiManager.clearOutput();
     if (this.game.inputMode === "normal") {
       this.game.gameLogic.playScene();

--- a/js/talentManager.js
+++ b/js/talentManager.js
@@ -1,0 +1,66 @@
+export class TalentManager {
+  constructor(game) {
+    this.game = game;
+    this.talents = [];
+    this.acquired = [];
+  }
+
+  async initialize() {
+    try {
+      const response = await fetch('/talents/talents.json');
+      if (!response.ok) throw new Error(`Failed to fetch talents: ${response.status}`);
+      const data = await response.json();
+      if (Array.isArray(data.talents)) {
+        this.talents = data.talents;
+      }
+    } catch (err) {
+      console.error('Failed to load talents:', err);
+    }
+  }
+
+  getTalent(id) {
+    return this.talents.find(t => t.id === id);
+  }
+
+  isTalentUnlocked(id) {
+    return this.acquired.includes(id);
+  }
+
+  unlockTalent(id) {
+    const talent = this.getTalent(id);
+    if (!talent || this.isTalentUnlocked(id)) return false;
+
+    const level = Math.floor(this.game.gameState.playerXp / (this.game.xpPerLevel || 100));
+    if (talent.requiredLevel && level < talent.requiredLevel) return false;
+    if (talent.prerequisites && !talent.prerequisites.every(pr => this.isTalentUnlocked(pr))) {
+      return false;
+    }
+
+    this.acquired.push(id);
+
+    if (talent.effects) {
+      if (talent.effects.unlockSpell) {
+        const spellId = talent.effects.unlockSpell;
+        if (!this.game.playerSpells.includes(spellId)) {
+          this.game.playerSpells.push(spellId);
+        }
+      }
+      if (talent.effects.statBonuses) {
+        Object.entries(talent.effects.statBonuses).forEach(([stat, val]) => {
+          this.game.playerStats[stat] = (this.game.playerStats[stat] || 0) + val;
+        });
+      }
+    }
+    return true;
+  }
+
+  save() {
+    return {
+      acquired: this.acquired
+    };
+  }
+
+  load(data) {
+    this.acquired = data?.acquired || [];
+  }
+}

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -1,0 +1,109 @@
+import { UIPanel } from './uiPanel.js';
+
+export class TalentTreeUI extends UIPanel {
+  constructor(game) {
+    const panel = document.getElementById('talent-panel');
+    super(panel);
+    this.game = game;
+    this.content = null;
+    this.closeButton = null;
+
+    if (document.readyState === 'complete') {
+      this.init();
+    } else {
+      document.addEventListener('DOMContentLoaded', () => this.init());
+    }
+  }
+
+  init() {
+    this.content = document.getElementById('talent-content');
+    this.closeButton = document.getElementById('close-talent');
+    if (!this.panel || !this.content || !this.closeButton) {
+      console.error('Talent panel elements not found');
+      return;
+    }
+    this.panel.classList.add('hidden');
+    this.closeButton.addEventListener('click', () => {
+      this.toggle(false);
+      if (this.game.inputHandlers && typeof this.game.inputHandlers.resumeAfterTalent === 'function') {
+        this.game.inputHandlers.resumeAfterTalent();
+      }
+    });
+  }
+
+  toggle(show = !this.visible) {
+    if (show) {
+      if (this.game.notesManager?.visible) this.game.notesManager.toggle(false);
+      if (this.game.mapManager?.visible) this.game.mapManager.toggle(false);
+      if (this.game.equipmentManagerUI?.visible) this.game.equipmentManagerUI.toggle(false);
+    } else if (this.visible) {
+      if (this.game.inputMode === 'talent') {
+        this.game.inputMode = this.game.previousMode || 'normal';
+        this.game.previousMode = null;
+      }
+    }
+    super.toggle(show);
+    if (this.visible) {
+      this.updateContent();
+    }
+  }
+
+  updateContent() {
+    if (!this.content || !this.visible) return;
+    this.content.innerHTML = '';
+
+    const points = this.game.gameState.talentPoints || 0;
+    const pointsEl = document.createElement('div');
+    pointsEl.className = 'talent-points';
+    pointsEl.textContent = `Talent Points: ${points}`;
+    this.content.appendChild(pointsEl);
+
+    const list = document.createElement('div');
+    list.className = 'talent-list';
+
+    (this.game.talentManager.talents || []).forEach(talent => {
+      const unlocked = this.game.talentManager.isTalentUnlocked(talent.id);
+      const item = document.createElement('div');
+      item.className = 'talent-item';
+
+      const title = document.createElement('h4');
+      title.textContent = talent.name;
+      item.appendChild(title);
+
+      const desc = document.createElement('p');
+      desc.textContent = talent.description;
+      item.appendChild(desc);
+
+      if (unlocked) {
+        const status = document.createElement('div');
+        status.className = 'talent-status';
+        status.textContent = 'Unlocked';
+        item.appendChild(status);
+      } else {
+        const req = document.createElement('div');
+        req.className = 'talent-req';
+        req.textContent = `Requires level ${talent.requiredLevel}`;
+        item.appendChild(req);
+
+        const prereqMet = (talent.prerequisites || []).every(pr => this.game.talentManager.isTalentUnlocked(pr));
+        const level = Math.floor(this.game.gameState.playerXp / (this.game.xpPerLevel || 100));
+        const canUnlock = prereqMet && level >= (talent.requiredLevel || 0) && points > 0;
+
+        const btn = document.createElement('button');
+        btn.textContent = 'Unlock';
+        btn.disabled = !canUnlock;
+        btn.addEventListener('click', () => {
+          if (this.game.talentManager.unlockTalent(talent.id)) {
+            this.game.gameState.talentPoints -= 1;
+            this.updateContent();
+            this.game.uiManager.print(`You unlocked the talent ${talent.name}!`, 'system-message');
+          }
+        });
+        item.appendChild(btn);
+      }
+      list.appendChild(item);
+    });
+
+    this.content.appendChild(list);
+  }
+}

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -8,11 +8,7 @@ export class TalentTreeUI extends UIPanel {
     this.content = null;
     this.closeButton = null;
 
-    if (document.readyState === 'complete') {
-      this.init();
-    } else {
-      document.addEventListener('DOMContentLoaded', () => this.init());
-    }
+    this.init();
   }
 
   init() {

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -6,6 +6,20 @@
       "description": "A small ball of fire hurled at your foe.",
       "damage": 6,
       "charges": 3
+    },
+    {
+      "id": "ice_bolt",
+      "name": "Ice Bolt",
+      "description": "A chilling shard of ice that pierces enemies.",
+      "damage": 5,
+      "charges": 3
+    },
+    {
+      "id": "frost_nova",
+      "name": "Frost Nova",
+      "description": "A burst of freezing air damaging everything nearby.",
+      "damage": 8,
+      "charges": 2
     }
   ]
 }

--- a/styles.css
+++ b/styles.css
@@ -545,6 +545,43 @@ h1, h2, h3, h4, h5, h6 {
   top: -100%; /* Hide above the viewport */
 }
 
+/* Talent Panel Styles */
+#talent-panel {
+  position: fixed;
+  right: -100%;
+  top: 0;
+  width: 100%;
+  height: 60%;
+  background-color: var(--bg-panel);
+  color: var(--text-color);
+  z-index: 100;
+  transition: right 0.3s ease-in-out;
+  overflow-y: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+#talent-panel.visible {
+  right: 0;
+}
+
+#talent-panel.hidden {
+  right: -100%;
+}
+
+.talent-item {
+  padding: 8px;
+  border-bottom: 1px solid #333;
+}
+
+.talent-item h4 {
+  margin: 0 0 5px 0;
+  color: #aad;
+}
+
+.talent-status {
+  color: #99ff99;
+}
+
 .equipment-section {
   padding: 10px 15px;
   margin-bottom: 15px;

--- a/talents/talents.json
+++ b/talents/talents.json
@@ -1,0 +1,24 @@
+{
+  "talents": [
+    {
+      "id": "apprentice_mage",
+      "name": "Apprentice Mage",
+      "description": "Study of basic magic, unlocking the Ice Bolt spell.",
+      "requiredLevel": 2,
+      "prerequisites": [],
+      "effects": {
+        "unlockSpell": "ice_bolt"
+      }
+    },
+    {
+      "id": "adept_mage",
+      "name": "Adept Mage",
+      "description": "Advanced magical training, unlocking the Frost Nova spell.",
+      "requiredLevel": 4,
+      "prerequisites": ["apprentice_mage"],
+      "effects": {
+        "unlockSpell": "frost_nova"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add sample talents and new spells
- load talents with TalentManager and display UI via TalentTreeUI
- save/load acquired talents and talent points
- grant talent points on level-up
- recognize `talents` or `skills` commands in input handlers

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68411b011f3483289db3b14bd01e5358