### PR TITLE
Delegate input to handlers and add talent panel

### DIFF
--- a/game.js
+++ b/game.js
@@ -20,6 +20,7 @@ import { EquipmentManager } from './js/equipmentManager.js';
 import { WeaponManager } from './js/weaponManager.js';
 import { SpellManager } from './js/spellManager.js';
 import { EquipmentManagerUI } from './js/equipmentManagerUI.js';
+import { TalentManager } from './js/talentManager.js';
 
 class TextGame {
   constructor() {
@@ -116,6 +117,7 @@ class TextGame {
     this.notesManager = new NotesManager(this);
     this.mapManager = new MapManager(this);
     this.equipmentManagerUI = new EquipmentManagerUI(this);
+    this.talentManager = new TalentManager(this);
     
     // Initialize everything
     this.init();
@@ -311,56 +313,7 @@ class TextGame {
   }
 
   handleInput() {
-    if (this.isTyping) return;
-    const rawInput = this.gameInput.value.trim();
-    this.uiManager.clearInput();
-    this.uiManager.print(`> ${rawInput}`, "player-input");
-    const input = this.inputMode === "loadGame" ? rawInput : rawInput.toLowerCase();
-    
-    switch (this.inputMode) {
-      case "title":
-        this.inputHandlers.handleTitleInput(input);
-        break;
-      case "normal":
-        this.inputHandlers.handleNormalInput(input);
-        break;
-      case "choices":
-        this.inputHandlers.handleChoiceInput(input);
-        break;
-      case "stats":
-        this.inputHandlers.handleStatInput(input);
-        break;
-      case "inventory":
-        this.inputHandlers.handleInventoryInput(input);
-        break;
-      case "loadGame":
-        this.inputHandlers.handleLoadGameInput(rawInput);
-        break;
-      case "errorRecovery":
-        this.inputHandlers.handleErrorRecoveryInput(input);
-        break;
-      case "combat":
-        this.inputHandlers.handleCombatInput(input);
-        break;
-      case "await-continue":
-        this.inputHandlers.handleAwaitContinueInput(input);
-        break;
-      case "await-combat":
-        this.inputHandlers.handleAwaitCombatInput(input);
-        break;
-      case "combat-item":
-        this.inputHandlers.handleCombatItemInput(input);
-        break;
-      case "combat-spell":
-        this.inputHandlers.handleCombatSpellInput(input);
-        break;
-      case "equipment":
-        this.inputHandlers.handleEquipmentInput(input);
-        break;
-      case "equip-confirm":
-        // This is handled by the equipItem method
-        break;
-    }
+    this.inputHandlers.handleInput();
   }
 
   async showLoadingScreen() {
@@ -618,6 +571,16 @@ class TextGame {
     }
   }
 
+  // Toggle talent panel
+  toggleTalents() {
+    if (this.talentManager) {
+      this.talentManager.toggle();
+    } else {
+      console.error("Talent manager not initialized");
+      this.uiManager.print("Talent panel is not available.", "error-message");
+    }
+  }
+
   // Add or update the saveNotes method
   saveNotes() {
     if (this.notesManager) {
@@ -652,6 +615,11 @@ class TextGame {
     if (this.equipmentManagerUI) {
       console.log("- Equipment panel element:", this.equipmentManagerUI.panel ? "Found" : "Not found");
     }
+
+    console.log("TalentManager:", this.talentManager ? "Initialized" : "Not initialized");
+    if (this.talentManager) {
+      console.log("- Talent panel element:", this.talentManager.panel ? "Found" : "Not found");
+    }
     
     return "Panel status logged to console";
   }
@@ -668,17 +636,21 @@ class TextGame {
     console.log("Map container:", document.getElementById('map-container') ? "Found" : "Missing");
     console.log("Equipment panel:", document.getElementById('equipment-panel') ? "Found" : "Missing");
     console.log("Equipment content:", document.getElementById('equipment-content') ? "Found" : "Missing");
+    console.log("Talent panel:", document.getElementById('talent-panel') ? "Found" : "Missing");
+    console.log("Talent content:", document.getElementById('talent-content') ? "Found" : "Missing");
     
     // Check managers
     console.log("\n=== MANAGER STATUS ===");
     console.log("Notes manager:", this.notesManager ? "Exists" : "Missing");
     console.log("Map manager:", this.mapManager ? "Exists" : "Missing");
     console.log("Equipment manager UI:", this.equipmentManagerUI ? "Exists" : "Missing");
+    console.log("Talent manager:", this.talentManager ? "Exists" : "Missing");
     
     // Check manager panels
     if (this.notesManager) console.log("- Notes panel in manager:", this.notesManager.panel ? "Found" : "Missing");
     if (this.mapManager) console.log("- Map panel in manager:", this.mapManager.panel ? "Found" : "Missing");
     if (this.equipmentManagerUI) console.log("- Equipment panel in manager:", this.equipmentManagerUI.panel ? "Found" : "Missing");
+    if (this.talentManager) console.log("- Talent panel in manager:", this.talentManager.panel ? "Found" : "Missing");
     
     // Check input mode
     console.log("\n=== GAME STATE ===");
@@ -708,6 +680,10 @@ class TextGame {
     
     if (this.equipmentManagerUI && this.equipmentManagerUI.visible) {
       this.equipmentManagerUI.toggle(false);
+    }
+
+    if (this.talentManager && this.talentManager.visible) {
+      this.talentManager.toggle(false);
     }
     
     // Force normal input mode

--- a/index.html
+++ b/index.html
@@ -55,7 +55,15 @@
       </div>
       <div id="equipment-content" class="panel-content"></div>
     </div>
-    
+
+    <div id="talent-panel" class="slide-out ui-panel hidden">
+      <div class="panel-header">
+        <h2>Talents</h2>
+        <button id="close-talents" class="close-button">×</button>
+      </div>
+      <div id="talent-content" class="panel-content"></div>
+    </div>
+
     <script type="module" src="game.js"></script>
   </body>
 </html>

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -14,13 +14,19 @@ export class InputHandlers {
       this.game.toggleNotes();
       return;
     }
-    
+
     // Add map command check
     if (input === "map" || input === "m") {
       this.game.toggleMap();
       return;
     }
-    
+
+    // Talent panel command
+    if (input === "talents" || input === "talent") {
+      this.game.toggleTalents();
+      return;
+    }
+
     // Then continue with existing combat input handling
     this.game.combatSystem.processPlayerAction(input);
   }
@@ -90,6 +96,12 @@ export class InputHandlers {
     // Add global map command check
     if (input === "map" || input === "m") {
       this.game.toggleMap();
+      return;
+    }
+
+    // Talent panel command
+    if (input === "talents" || input === "talent") {
+      this.game.toggleTalents();
       return;
     }
 
@@ -169,6 +181,12 @@ export class InputHandlers {
     // Check for map command
     if (input === "map" || input === "m") {
       this.game.toggleMap();
+      return;
+    }
+
+    // Check for talents command
+    if (input === "talents" || input === "talent") {
+      this.game.toggleTalents();
       return;
     }
     
@@ -639,6 +657,7 @@ export class InputHandlers {
     this.game.uiManager.print("equipment, equip - Show your equipped items", "help-text");
     this.game.uiManager.print("notes, note - Open/close the notes panel", "help-text");
     this.game.uiManager.print("map, m - Open/close the map", "help-text");
+    this.game.uiManager.print("talents, talent - Open/close the talent panel", "help-text");
     this.game.uiManager.print("save - Save your game", "help-text");
     this.game.uiManager.print("load - Load a saved game", "help-text");
     this.game.uiManager.print("quit, exit, title - Return to title screen", "help-text");

--- a/js/talentManager.js
+++ b/js/talentManager.js
@@ -1,0 +1,53 @@
+import { UIPanel } from './uiPanel.js';
+
+export class TalentManager extends UIPanel {
+  constructor(game) {
+    const panel = document.getElementById('talent-panel');
+    super(panel);
+    this.game = game;
+    this.content = null;
+
+    if (document.readyState === 'complete') {
+      this.init();
+    } else {
+      document.addEventListener('DOMContentLoaded', () => this.init());
+    }
+  }
+
+  init() {
+    this.content = document.getElementById('talent-content');
+    this.closeButton = document.getElementById('close-talents');
+
+    if (!this.panel || !this.content || !this.closeButton) {
+      console.error('Talent panel elements not found in the DOM');
+      return;
+    }
+
+    this.closeButton.addEventListener('click', () => this.toggle(false));
+    this.panel.classList.add('hidden');
+  }
+
+  updateContent() {
+    if (!this.content) return;
+    this.content.innerHTML = '<p>Talent panel not implemented yet.</p>';
+  }
+
+  toggle(show = !this.visible) {
+    if (show && this.game) {
+      // Close other panels when opening this one
+      if (this.game.notesManager && this.game.notesManager.visible) {
+        this.game.notesManager.toggle(false);
+      }
+      if (this.game.mapManager && this.game.mapManager.visible) {
+        this.game.mapManager.toggle(false);
+      }
+      if (this.game.equipmentManagerUI && this.game.equipmentManagerUI.visible) {
+        this.game.equipmentManagerUI.toggle(false);
+      }
+    }
+    super.toggle(show);
+    if (this.visible) {
+      this.updateContent();
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -545,6 +545,29 @@ h1, h2, h3, h4, h5, h6 {
   top: -100%; /* Hide above the viewport */
 }
 
+/* Talent Panel Styles */
+#talent-panel {
+  position: fixed;
+  bottom: -100%;
+  left: 0;
+  width: 100%;
+  height: 40%;
+  background-color: var(--bg-panel);
+  color: var(--text-color);
+  z-index: 100;
+  transition: bottom 0.3s ease-in-out;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.5);
+  overflow-y: auto;
+}
+
+#talent-panel.visible {
+  bottom: 0;
+}
+
+#talent-panel.hidden {
+  bottom: -100%;
+}
+
 .equipment-section {
   padding: 10px 15px;
   margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- delegate all input handling through `InputHandlers.handleInput`
- add a new talent panel with basic manager
- hook up `talents` command and update help text

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6841206ce9a88328a70f6ef90fdc999e