### PR TITLE
Remove unused slide-out class

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       <div id="notes-editor" contenteditable="true" class="notes-editor"></div>
     </div>
 
-    <div id="equipment-panel" class="slide-out ui-panel hidden">
+    <div id="equipment-panel" class="ui-panel hidden">
       <div class="panel-header">
         <h2>Equipment</h2>
         <button id="close-equipment" class="close-button">×</button>


### PR DESCRIPTION
## Summary
- drop unused `slide-out` class from the equipment panel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68422ab26c688328acc3de3544ce29cc