### PR TITLE
Add Talent Tree UI

### DIFF
--- a/game.js
+++ b/game.js
@@ -20,6 +20,7 @@ import { EquipmentManager } from './js/equipmentManager.js';
 import { WeaponManager } from './js/weaponManager.js';
 import { SpellManager } from './js/spellManager.js';
 import { EquipmentManagerUI } from './js/equipmentManagerUI.js';
+import { TalentTreeUI } from './js/talentTreeUI.js';
 
 class TextGame {
   constructor() {
@@ -116,6 +117,7 @@ class TextGame {
     this.notesManager = new NotesManager(this);
     this.mapManager = new MapManager(this);
     this.equipmentManagerUI = new EquipmentManagerUI(this);
+    this.talentTreeUI = new TalentTreeUI(this);
     
     // Initialize everything
     this.init();
@@ -615,6 +617,16 @@ class TextGame {
     } else {
       console.error("Map manager not initialized");
       this.uiManager.print("Map panel is not available.", "error-message");
+    }
+  }
+
+  // Toggle talent panel
+  toggleTalentTree() {
+    if (this.talentTreeUI) {
+      this.talentTreeUI.toggle();
+    } else {
+      console.error("Talent tree UI not initialized");
+      this.uiManager.print("Talent panel is not available.", "error-message");
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -55,6 +55,14 @@
       </div>
       <div id="equipment-content" class="panel-content"></div>
     </div>
+
+    <div id="talent-panel" class="talent-panel ui-panel hidden">
+      <div class="panel-header">
+        <h2>Talents</h2>
+        <button id="close-talent" class="close-button">×</button>
+      </div>
+      <div id="talent-content" class="panel-content"></div>
+    </div>
     
     <script type="module" src="game.js"></script>
   </body>

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -20,6 +20,11 @@ export class InputHandlers {
       this.game.toggleMap();
       return;
     }
+
+    if (input === "talents" || input === "talent" || input === "t") {
+      this.game.toggleTalentTree();
+      return;
+    }
     
     // Then continue with existing combat input handling
     this.game.combatSystem.processPlayerAction(input);
@@ -171,7 +176,13 @@ export class InputHandlers {
       this.game.toggleMap();
       return;
     }
-    
+
+    // Check for talent command
+    if (input === "talents" || input === "talent" || input === "t") {
+      this.game.toggleTalentTree();
+      return;
+    }
+
     // Check for equipment command
     if (input === "equipment" || input === "equip" || input === "e") {
       this.game.toggleEquipment();
@@ -210,6 +221,11 @@ export class InputHandlers {
     // Add map command handling for choices mode
     if (input === "map" || input === "m") {
       this.game.toggleMap();
+      return;
+    }
+
+    if (input === "talents" || input === "talent" || input === "t") {
+      this.game.toggleTalentTree();
       return;
     }
 
@@ -255,7 +271,12 @@ export class InputHandlers {
       this.game.toggleMap();
       return;
     }
-    
+
+    if (input === "talents" || input === "talent" || input === "t") {
+      this.game.toggleTalentTree();
+      return;
+    }
+
     const inputLower = input.toLowerCase();
     
     // Special handling for "back" during initial allocation
@@ -639,6 +660,7 @@ export class InputHandlers {
     this.game.uiManager.print("equipment, equip - Show your equipped items", "help-text");
     this.game.uiManager.print("notes, note - Open/close the notes panel", "help-text");
     this.game.uiManager.print("map, m - Open/close the map", "help-text");
+    this.game.uiManager.print("talents, talent, t - Open/close the talent tree", "help-text");
     this.game.uiManager.print("save - Save your game", "help-text");
     this.game.uiManager.print("load - Load a saved game", "help-text");
     this.game.uiManager.print("quit, exit, title - Return to title screen", "help-text");

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -19,7 +19,10 @@ export class TalentTreeUI extends UIPanel {
       return;
     }
 
-    this.panel.classList.add('hidden');
+    if (!this.visible) {
+      this.panel.style.display = 'none';
+      this.panel.classList.add('hidden');
+    }
     this.closeButton.addEventListener('click', () => this.toggle(false));
   }
 

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -1,0 +1,40 @@
+import { UIPanel } from './uiPanel.js';
+
+export class TalentTreeUI extends UIPanel {
+  constructor(game) {
+    const panel = document.getElementById('talent-panel');
+    super(panel);
+    this.game = game;
+    this.content = null;
+    this.closeButton = null;
+    this.init();
+  }
+
+  init() {
+    this.content = document.getElementById('talent-content');
+    this.closeButton = document.getElementById('close-talent');
+
+    if (!this.panel || !this.content || !this.closeButton) {
+      console.error('Talent panel elements not found in the DOM');
+      return;
+    }
+
+    this.panel.classList.add('hidden');
+    this.closeButton.addEventListener('click', () => this.toggle(false));
+  }
+
+  toggle(show = !this.visible) {
+    if (show && this.game.equipmentManagerUI?.visible) {
+      this.game.equipmentManagerUI.toggle(false);
+    }
+    super.toggle(show);
+    if (show) {
+      this.updateContent();
+    }
+  }
+
+  updateContent() {
+    if (!this.content) return;
+    this.content.innerHTML = '<p>Here you will be able to spend talent points.</p>';
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -545,6 +545,37 @@ h1, h2, h3, h4, h5, h6 {
   top: -100%; /* Hide above the viewport */
 }
 
+/* Talent Panel Styles */
+#talent-panel {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 35%;
+  height: 100%;
+  background-color: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 100;
+}
+
+#talent-panel.visible {
+  transform: translateX(0);
+}
+
+#talent-panel.hidden {
+  transform: translateX(100%);
+}
+
+#close-talent {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 20px;
+  cursor: pointer;
+}
+
 .equipment-section {
   padding: 10px 15px;
   margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- add a new talent panel to the HTML and style it
- implement `TalentTreeUI` and initialize unconditionally
- wire talent tree commands through `InputHandlers`
- support toggling the talent screen from `TextGame`

## Testing
- `node -c js/talentTreeUI.js`
- `node -c game.js`
- `node -c js/inputHandlers.js`

------
https://chatgpt.com/codex/tasks/task_e_6841206d9efc8328af87326c631c89f8