### PR TITLE
Fix TalentManager import to restore startup

### DIFF
--- a/game.js
+++ b/game.js
@@ -20,6 +20,7 @@ import { EquipmentManager } from './js/equipmentManager.js';
 import { WeaponManager } from './js/weaponManager.js';
 import { SpellManager } from './js/spellManager.js';
 import { EquipmentManagerUI } from './js/equipmentManagerUI.js';
+import { TalentManager } from './js/talentManager.js';
 import { TalentTreeUI } from './js/talentTreeUI.js';
 
 class TextGame {


### PR DESCRIPTION
## Summary
- restore missing TalentManager import

This fixes a runtime ReferenceError that prevented the game from loading the title screen.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842303d36cc83289b32df41caae4132