### PR TITLE
Fix duplicate title screen display

### DIFF
--- a/game.js
+++ b/game.js
@@ -156,8 +156,6 @@ class TextGame {
       
       // Then load story content
       await this.loadStoryIndex();
-      
-      this.showTitleScreen();
     } catch (error) {
       console.error("Error during initialization:", error);
       this.uiManager.print("Error loading game resources. Please refresh the page.", "error-message");


### PR DESCRIPTION
## Summary
- remove redundant `showTitleScreen` call so the title appears only once after loading

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684234e6cc1c8328900b2fc3c896f055