### PR TITLE
Standardize panels and access rules

### DIFF
--- a/game.js
+++ b/game.js
@@ -150,6 +150,15 @@ class TextGame {
     }
   }
 
+  // Check if the game is in a phase where panels are allowed
+  isGameplayPhase() {
+    const phases = [
+      'normal', 'choices', 'combat', 'combat-item',
+      'combat-spell', 'await-combat', 'await-continue'
+    ];
+    return phases.includes(this.inputMode);
+  }
+
   async initialize() {
     this.uiManager.clearOutput();
     this.uiManager.print("Welcome to Olaf vs Bears", "system-message");
@@ -587,8 +596,20 @@ class TextGame {
 
   // Toggle notes panel
   toggleNotes() {
+    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+      this.uiManager.print('Notes can only be accessed during gameplay.', 'system-message');
+      return;
+    }
     if (this.notesManager) {
-      this.notesManager.toggle();
+      const show = !this.notesManager.visible;
+      if (show) {
+        this.previousMode = this.inputMode;
+        this.inputMode = 'notes';
+      } else if (this.inputMode === 'notes') {
+        this.inputMode = this.previousMode || 'normal';
+        this.previousMode = null;
+      }
+      this.notesManager.toggle(show);
     } else {
       console.error("Notes manager not initialized");
       this.uiManager.print("Notes panel is not available.", "error-message");
@@ -597,8 +618,20 @@ class TextGame {
 
   // Toggle map panel
   toggleMap() {
+    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+      this.uiManager.print('Map can only be accessed during gameplay.', 'system-message');
+      return;
+    }
     if (this.mapManager) {
-      this.mapManager.toggle();
+      const show = !this.mapManager.visible;
+      if (show) {
+        this.previousMode = this.inputMode;
+        this.inputMode = 'map';
+      } else if (this.inputMode === 'map') {
+        this.inputMode = this.previousMode || 'normal';
+        this.previousMode = null;
+      }
+      this.mapManager.toggle(show);
     } else {
       console.error("Map manager not initialized");
       this.uiManager.print("Map panel is not available.", "error-message");
@@ -607,8 +640,20 @@ class TextGame {
 
   // Toggle talent panel
   toggleTalentTree() {
+    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+      this.uiManager.print('Talents can only be accessed during gameplay.', 'system-message');
+      return;
+    }
     if (this.talentTreeUI) {
-      this.talentTreeUI.toggle();
+      const show = !this.talentTreeUI.visible;
+      if (show) {
+        this.previousMode = this.inputMode;
+        this.inputMode = 'talent';
+      } else if (this.inputMode === 'talent') {
+        this.inputMode = this.previousMode || 'normal';
+        this.previousMode = null;
+      }
+      this.talentTreeUI.toggle(show);
     } else {
       console.error("Talent tree UI not initialized");
       this.uiManager.print("Talent panel is not available.", "error-message");
@@ -619,6 +664,10 @@ class TextGame {
   toggleStats(show) {
     if (this.inputMode === 'title' || this.inputMode === 'loadGame') {
       this.uiManager.print('Stats are not available right now.', 'system-message');
+      return;
+    }
+    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+      this.uiManager.print('Stats can only be accessed during gameplay.', 'system-message');
       return;
     }
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     </div>
     
     <div id="notes-panel" class="notes-panel ui-panel hidden">
-      <div class="notes-header">
+      <div class="panel-header notes-header">
         <h3>Notes</h3>
         <button id="close-notes">×</button>
       </div>

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -1254,4 +1254,52 @@ saveGame() {
       this.game.combatSystem.showCombatOptions();
     }
   }
+
+  resumeAfterMap() {
+    if (this.game.mapManager) {
+      this.game.mapManager.toggle(false);
+    }
+
+    this.game.inputMode = this.game.previousMode || "normal";
+    this.game.previousMode = null;
+
+    this.game.uiManager.clearOutput();
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
+      this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
+    }
+  }
+
+  resumeAfterNotes() {
+    if (this.game.notesManager) {
+      this.game.notesManager.toggle(false);
+    }
+
+    this.game.inputMode = this.game.previousMode || "normal";
+    this.game.previousMode = null;
+
+    this.game.uiManager.clearOutput();
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
+      this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
+    }
+  }
+
+  resumeAfterStats() {
+    if (this.game.statsPanel) {
+      this.game.statsPanel.toggle(false);
+    }
+
+    this.game.inputMode = this.game.previousMode || "normal";
+    this.game.previousMode = null;
+
+    this.game.uiManager.clearOutput();
+    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
+      this.game.gameLogic.playScene();
+    } else if (this.game.inputMode === "combat") {
+      this.game.combatSystem.showCombatOptions();
+    }
+  }
 }

--- a/js/map.js
+++ b/js/map.js
@@ -35,7 +35,12 @@ export class MapManager extends UIPanel {
     
     // Setup map event listeners with a direct close method
     if (closeMapBtn) {
-      closeMapBtn.addEventListener('click', () => this.close());
+      closeMapBtn.addEventListener('click', () => {
+        this.close();
+        if (this.game.inputHandlers && typeof this.game.inputHandlers.resumeAfterMap === 'function') {
+          this.game.inputHandlers.resumeAfterMap();
+        }
+      });
       console.log("Close map button event listener attached");
     } else {
       console.error("Close map button not found!");

--- a/js/notes.js
+++ b/js/notes.js
@@ -35,7 +35,12 @@ export class NotesManager extends UIPanel {
     }
     
     // Setup event listeners
-    closeNotesBtn.addEventListener('click', () => this.toggle(false));
+    closeNotesBtn.addEventListener('click', () => {
+      this.toggle(false);
+      if (this.game.inputHandlers && typeof this.game.inputHandlers.resumeAfterNotes === 'function') {
+        this.game.inputHandlers.resumeAfterNotes();
+      }
+    });
     
     // Setup rich text formatting
     this.setupRichTextEditing();

--- a/js/statsPanel.js
+++ b/js/statsPanel.js
@@ -13,7 +13,12 @@ export class StatsPanel extends UIPanel {
   init() {
     if (!this.panel) return;
     if (this.closeButton) {
-      this.closeButton.addEventListener('click', () => this.game.toggleStats(false));
+      this.closeButton.addEventListener('click', () => {
+        this.game.toggleStats(false);
+        if (this.game.inputHandlers && typeof this.game.inputHandlers.resumeAfterStats === 'function') {
+          this.game.inputHandlers.resumeAfterStats();
+        }
+      });
     }
     if (!this.visible) {
       this.panel.style.display = 'none';

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -23,7 +23,12 @@ export class TalentTreeUI extends UIPanel {
       this.panel.style.display = 'none';
       this.panel.classList.add('hidden');
     }
-    this.closeButton.addEventListener('click', () => this.toggle(false));
+    this.closeButton.addEventListener('click', () => {
+      this.toggle(false);
+      if (this.game.inputHandlers && typeof this.game.inputHandlers.resumeAfterTalent === 'function') {
+        this.game.inputHandlers.resumeAfterTalent();
+      }
+    });
   }
 
   toggle(show = !this.visible) {

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,31 @@ h1, h2, h3, h4, h5, h6 {
   opacity: 1;
 }
 
+/* Standardized header style for all panels */
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--bg-main);
+  padding: 10px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: var(--heading-font);
+}
+
+.panel-header h2,
+.panel-header h3 {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.close-button {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 20px;
+  cursor: pointer;
+}
+
 .game-container {
   max-width: 800px;
   height: auto;
@@ -342,16 +367,7 @@ h1, h2, h3, h4, h5, h6 {
   transform: translateX(100%);
 }
 
-.notes-header {
-  padding: 10px;
-  background-color: var(--bg-main);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .notes-header h3 {
-  margin: 0;
   color: #ddd;
 }
 


### PR DESCRIPTION
## Summary
- standardize panel header styles
- restrict panel toggles to gameplay phases
- restore previous mode when closing map, notes, stats, and talents
- add resume helpers for map, notes, and stats

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68425288b2248328bdb63dbdbc8c547d