### PR TITLE
Improve menu UX for load game

### DIFF
--- a/game.js
+++ b/game.js
@@ -96,6 +96,7 @@ class TextGame {
 
     this.gameInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
+        e.preventDefault();
         this.handleInput();
       }
       if (e.code === "Space" && this.isTyping) {
@@ -180,6 +181,9 @@ class TextGame {
   async showTitleScreen() {
     let titleText;
     await fadeTransition(async () => {
+      if (this.gameInput) {
+        this.gameInput.rows = 1;
+      }
       document.body.classList.add("title-screen");
       this.uiManager.clearOutput();
       const titleContainer = document.createElement("div");

--- a/game.js
+++ b/game.js
@@ -666,17 +666,20 @@ class TextGame {
 
   // Toggle stats panel
   toggleStats(show) {
-    if (this.inputMode === 'title' || this.inputMode === 'loadGame') {
-      this.uiManager.print('Stats are not available right now.', 'system-message');
-      return;
-    }
-    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
-      this.uiManager.print('Stats can only be accessed during gameplay.', 'system-message');
-      return;
+    if (this.statsPanel && show === undefined) show = !this.statsPanel.visible;
+
+    if (show) {
+      if (this.inputMode === 'title' || this.inputMode === 'loadGame') {
+        this.uiManager.print('Stats are not available right now.', 'system-message');
+        return;
+      }
+      if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+        this.uiManager.print('Stats can only be accessed during gameplay.', 'system-message');
+        return;
+      }
     }
 
     if (this.statsPanel) {
-      if (show === undefined) show = !this.statsPanel.visible;
       if (show) {
         this.previousMode = this.inputMode;
         this.inputMode = 'stats';

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       <div id="gameOutput" class="game-output"></div>
       <div class="input-container">
         <div class="prompt">&gt;</div>
-        <input id="gameInput" class="game-input" type="text" autocomplete="off">
+        <textarea id="gameInput" class="game-input" rows="1" autocomplete="off"></textarea>
         <button id="musicToggle" class="music-toggle">Toggle Music</button>
       </div>
     </div>

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -82,6 +82,11 @@ export class InputHandlers {
     if (this.game.isTyping) return; // Don't process input while text is typing
 
     const rawInput = this.game.gameInput.value.trim();
+    // Remove previous player input and transient messages
+    this.game.gameOutput
+      .querySelectorAll('.player-input, .error-message, .system-message')
+      .forEach((el) => el.remove());
+
     this.game.uiManager.clearInput();
     this.game.uiManager.print(`> ${rawInput}`, "player-input");
 

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -82,9 +82,10 @@ export class InputHandlers {
     if (this.game.isTyping) return; // Don't process input while text is typing
 
     const rawInput = this.game.gameInput.value.trim();
-    // Remove previous player input and transient messages
+    // Remove previous player input and error messages
+    // Keep system messages like "Type 'continue'" until they are replaced
     this.game.gameOutput
-      .querySelectorAll('.player-input, .error-message, .system-message')
+      .querySelectorAll('.player-input, .error-message')
       .forEach((el) => el.remove());
 
     this.game.uiManager.clearInput();

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -166,7 +166,12 @@ export class InputHandlers {
     } else if (input === "2" || input.toLowerCase() === "load game") {
       this.showLoadGamePrompt();
     } else {
-      this.game.uiManager.print("Invalid option. Please type 1 for New Game or 2 for Load Game.", "error-message");
+      this.game.showTitleScreen().then(() => {
+        this.game.uiManager.print(
+          "Invalid option. Please type 1 for New Game or 2 for Load Game.",
+          "error-message"
+        );
+      });
     }
   }
 
@@ -594,8 +599,11 @@ export class InputHandlers {
     this.game.gameOutput.appendChild(subtitleElement);
     
     await this.game.uiManager.typeIntoElement(subtitleElement, "Paste your save code below or type 'back' to return:", this.game.typingSpeed, this.game.audioManager);
-    
+
     this.game.inputMode = "loadGame";
+    if (this.game.gameInput) {
+      this.game.gameInput.rows = 4;
+    }
   }
 
   async makeChoice(nextScene) {
@@ -841,6 +849,9 @@ saveGame() {
       this.game.uiManager.print("Game loaded successfully!", "system-message");
       setTimeout(() => {
         this.game.uiManager.clearOutput();
+        if (this.game.gameInput) {
+          this.game.gameInput.rows = 1;
+        }
         this.game.inputMode = "normal";
         this.game.gameLogic.playScene();
       }, 1500);

--- a/js/ui.js
+++ b/js/ui.js
@@ -29,6 +29,11 @@ export class UIManager {
   print(text, className = "") {
     const element = document.createElement("div");
     if (className) element.className = className;
+    if (className === "system-message") {
+      this.gameOutput
+        .querySelectorAll(".system-message")
+        .forEach((el) => el.remove());
+    }
     element.textContent = text;
     this.gameOutput.appendChild(element);
     this.gameOutput.scrollTop = this.gameOutput.scrollHeight;

--- a/js/ui.js
+++ b/js/ui.js
@@ -29,9 +29,9 @@ export class UIManager {
   print(text, className = "") {
     const element = document.createElement("div");
     if (className) element.className = className;
-    if (className === "system-message") {
+    if (className === "system-message" || className === "error-message") {
       this.gameOutput
-        .querySelectorAll(".system-message")
+        .querySelectorAll(`.${className}`)
         .forEach((el) => el.remove());
     }
     element.textContent = text;

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,10 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: 4px;
   outline: none;
   transition: box-shadow 0.2s;
+  resize: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-y: auto;
 }
 
 .game-input:focus {


### PR DESCRIPTION
## Summary
- replace the main input with a `<textarea>`
- allow wrapping and scrolling of long text
- reset the input back to one line on the title screen
- clear invalid main menu entries
- wrap save code input when loading a game

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68436f3660a08328b21d09bc34178068