### PR TITLE
Add UI output helpers and improve inventory resume

### DIFF
--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -5,6 +5,7 @@ export class InputHandlers {
     this.game = game;
     this.isInitialAllocation = false; // Flag to track if we're in initial character creation
     this.awaitingUnspentPointsConfirmation = false; // New flag to track if we're waiting for confirmation
+    this.savedOutput = '';
   }
 
   // Add a new method to handle combat input
@@ -667,12 +668,11 @@ export class InputHandlers {
   resumeAfterInventory() {
     this.game.inputMode = this.game.previousMode || "normal";
     this.game.previousMode = null;
-    this.game.uiManager.clearOutput();
-    if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
-      this.game.gameLogic.playScene();
-    } else if (this.game.inputMode === "combat") {
+    this.game.uiManager.setOutputHTML(this.savedOutput);
+    if (this.game.inputMode === "combat") {
       this.game.combatSystem.showCombatOptions();
     }
+    this.game.uiManager.focusInput();
   }
 
   showInventory() {
@@ -680,6 +680,7 @@ export class InputHandlers {
     if (this.game.inputMode !== "inventory") {
       this.game.previousMode = this.game.inputMode;
     }
+    this.savedOutput = this.game.uiManager.getOutputHTML();
     this.game.inputMode = "inventory";
     this.game.uiManager.clearOutput();
     this.game.uiManager.print("===== INVENTORY =====", "system-message");

--- a/js/ui.js
+++ b/js/ui.js
@@ -63,6 +63,14 @@ export class UIManager {
   hideInputContainer() {
     this.inputContainer.style.display = 'none';
   }
+
+  getOutputHTML() {
+    return this.gameOutput.innerHTML;
+  }
+
+  setOutputHTML(html) {
+    this.gameOutput.innerHTML = html;
+  }
 }
 
 export async function fadeTransition(callback) {


### PR DESCRIPTION
## Summary
- add `getOutputHTML` and `setOutputHTML` helpers to `UIManager`
- save original output in `InputHandlers` and restore it after closing inventory
- refresh combat options only when resuming combat
- always refocus the input field when leaving inventory

## Testing
- `node -e "require('./js/inputHandlers.js');"`
- `node -e "require('./js/ui.js');"`


------
https://chatgpt.com/codex/tasks/task_e_68437d68a93083288ca6c78e9999891e