### PR TITLE
Add context menu for equipped slots

### DIFF
--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -733,7 +733,7 @@ export class InputHandlers {
       this.removeItemFromInventory(item.id);
       
       // Refresh inventory view
-      if (this.game.inventoryPanel) this.game.inventoryPanel.updateContent();
+      if (this.game.inventoryPanel) this.game.inventoryPanel.update();
       return;
     }
     

--- a/js/inventoryPanel.js
+++ b/js/inventoryPanel.js
@@ -34,23 +34,96 @@ export class InventoryPanel extends UIPanel {
       if (this.game.mapManager?.visible) this.game.mapManager.toggle(false);
     }
     super.toggle(show);
-    if (show) this.updateContent();
+    if (show) this.update();
   }
 
-  updateContent() {
+  update() {
     if (!this.content) return;
     this.content.innerHTML = '';
+
+    // ----- Equipped Items Section -----
+    const equipSection = document.createElement('div');
+    equipSection.className = 'equipment-section';
+
+    const equipment = this.game.equipmentManager?.getAllEquipment?.() || {};
+    ['weapon', 'armor', 'accessory'].forEach(slot => {
+      const slotDiv = document.createElement('div');
+      slotDiv.className = 'equipment-slot';
+      slotDiv.dataset.slot = slot;
+      const item = equipment[slot];
+      slotDiv.textContent = item ? item.name : `Empty ${slot}`;
+      slotDiv.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        this.showEquippedContextMenu(e.pageX, e.pageY, slot);
+      });
+      equipSection.appendChild(slotDiv);
+    });
+
+    this.content.appendChild(equipSection);
+
+    // ----- Inventory Items Section -----
     if (!this.game.inventory || this.game.inventory.length === 0) {
       const p = document.createElement('p');
       p.textContent = 'Your inventory is empty.';
       this.content.appendChild(p);
       return;
     }
+
     this.game.inventory.forEach(item => {
       const div = document.createElement('div');
       div.className = 'inventory-item';
       div.textContent = `${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ''}`;
       this.content.appendChild(div);
     });
+  }
+
+  showEquippedContextMenu(x, y, slot) {
+    const existing = this.panel.querySelector('.equipped-context-menu');
+    if (existing) existing.remove();
+
+    const menu = document.createElement('div');
+    menu.className = 'equipped-context-menu';
+    menu.style.left = `${x}px`;
+    menu.style.top = `${y}px`;
+
+    const equipment = this.game.equipmentManager?.getAllEquipment?.() || {};
+    const item = equipment[slot];
+
+    if (item) {
+      const examine = document.createElement('div');
+      examine.className = 'context-menu-option';
+      examine.textContent = 'Examine';
+      examine.addEventListener('click', () => {
+        this.game.inputHandlers.examineEquippedItem(slot);
+        menu.remove();
+      });
+      menu.appendChild(examine);
+
+      const unequip = document.createElement('div');
+      unequip.className = 'context-menu-option';
+      unequip.textContent = 'Unequip';
+      unequip.addEventListener('click', () => {
+        if (this.game.inventoryManager.items.length >= 20) {
+          this.game.uiManager.print('Your inventory is full.', 'inventory-message');
+        } else {
+          this.game.inputHandlers.unequipItem(slot);
+          this.update();
+        }
+        menu.remove();
+      });
+      menu.appendChild(unequip);
+    } else {
+      const empty = document.createElement('div');
+      empty.className = 'context-menu-option disabled';
+      empty.textContent = 'Nothing equipped';
+      menu.appendChild(empty);
+    }
+
+    const closeMenu = () => menu.remove();
+    setTimeout(() => {
+      document.addEventListener('click', closeMenu, { once: true });
+    }, 0);
+
+    this.panel.appendChild(menu);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -728,6 +728,38 @@ h1, h2, h3, h4, h5, h6 {
   background-color: #366a9c;
 }
 
+/* Context menu for equipped items */
+.equipped-context-menu {
+  position: absolute;
+  background-color: #222;
+  border: 1px solid var(--border-color);
+  z-index: 200;
+  padding: 5px;
+  display: flex;
+  flex-direction: column;
+}
+
+.equipped-context-menu .context-menu-option {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.equipped-context-menu .context-menu-option:hover {
+  background-color: var(--border-color);
+}
+
+.equipment-slot {
+  padding: 6px 8px;
+  border: 1px solid #444;
+  margin-bottom: 5px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.inventory-message {
+  color: #ff7777;
+}
+
 .stats-section {
   background-color: #262626;
   padding: 10px;


### PR DESCRIPTION
## Summary
- enhance `InventoryPanel` with context menu on equipped slots
- add `showEquippedContextMenu` for examine/unequip actions
- update inventory panel refresh calls
- style context menu and inventory messages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68438c51b4c8832887144d2aab301573