### PR TITLE
Add context menus for equipped items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1143,3 +1143,26 @@ body.title-screen .game-container {
 .inventory-context-menu .context-option:hover {
   background-color: #555;
 }
+
+/* Equipment context menu */
+.equipment-context-menu {
+  position: absolute;
+  background-color: #222;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #fff;
+  z-index: 200;
+}
+
+.equipment-context-menu.hidden {
+  display: none;
+}
+
+.equipment-context-menu .context-option {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.equipment-context-menu .context-option:hover {
+  background-color: #555;
+}


### PR DESCRIPTION
## Summary
- support context menus on equipped slots in inventory panel
- allow examining or unequipping equipped items if there is room
- show error when inventory is full
- style equipment context menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684394f7b4a0832888e5d280d2fb57c0