### PR TITLE
Add interactive talent tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,10 @@
         <h2>Talents</h2>
         <button id="close-talent" class="close-button">×</button>
       </div>
-      <div id="talent-content" class="panel-content"></div>
+      <div id="talent-content" class="panel-content">
+        <div id="talent-points" class="talent-points"></div>
+        <div id="talent-grid" class="talent-grid"></div>
+      </div>
     </div>
 
     <div id="audio-panel" class="audio-panel ui-panel hidden">

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -128,14 +128,7 @@ export class InputHandlers {
     }
 
     if (input === "talents" || input === "skills" || input === "talent") {
-      if (this.game.inputMode === "normal" || this.game.inputMode === "choices") {
-        this.game.toggleTalentTree();
-      } else {
-        this.game.uiManager.print(
-          "Talents can only be accessed during story mode.",
-          "system-message"
-        );
-      }
+      this.game.toggleTalentTree();
       return;
     }
 

--- a/js/talentManager.js
+++ b/js/talentManager.js
@@ -30,6 +30,13 @@ export class TalentManager {
     const talent = this.getTalent(id);
     if (!talent || this.isTalentUnlocked(id)) return false;
 
+    if (talent.tier && this.acquired.some(tid => {
+      const t = this.getTalent(tid);
+      return t && t.tier === talent.tier;
+    })) {
+      return false;
+    }
+
     const level = Math.floor(this.game.gameState.playerXp / (this.game.xpPerLevel || 100));
     if (talent.requiredLevel && level < talent.requiredLevel) return false;
     if (talent.prerequisites && !talent.prerequisites.every(pr => this.isTalentUnlocked(pr))) {

--- a/js/talentTreeUI.js
+++ b/js/talentTreeUI.js
@@ -7,12 +7,16 @@ export class TalentTreeUI extends UIPanel {
     this.game = game;
     this.content = null;
     this.closeButton = null;
+    this.pointsEl = null;
+    this.gridEl = null;
     this.init();
   }
 
   init() {
     this.content = document.getElementById('talent-content');
     this.closeButton = document.getElementById('close-talent');
+    this.pointsEl = document.getElementById('talent-points');
+    this.gridEl = document.getElementById('talent-grid');
 
     if (!this.panel || !this.content || !this.closeButton) {
       console.error('Talent panel elements not found in the DOM');
@@ -42,7 +46,64 @@ export class TalentTreeUI extends UIPanel {
   }
 
   updateContent() {
-    if (!this.content) return;
-    this.content.innerHTML = '<p>Here you will be able to spend talent points.</p>';
+    if (!this.gridEl || !this.pointsEl) return;
+
+    this.pointsEl.textContent = `Available points: ${this.game.gameState.talentPoints || 0}`;
+
+    this.gridEl.innerHTML = '';
+    const tiers = [...new Set(this.game.talentManager.talents.map(t => t.tier))].sort();
+    tiers.forEach(tier => {
+      const row = document.createElement('div');
+      row.className = 'talent-row';
+
+      const acquiredInTier = this.game.talentManager.acquired.some(id => {
+        const t = this.game.talentManager.getTalent(id);
+        return t && t.tier === tier;
+      });
+
+      this.game.talentManager.talents
+        .filter(t => t.tier === tier)
+        .forEach(talent => {
+          const box = document.createElement('div');
+          box.className = 'talent-option';
+          box.title = `${talent.name}: ${talent.description}`;
+          if (this.game.talentManager.isTalentUnlocked(talent.id)) {
+            box.classList.add('active');
+          } else if (acquiredInTier) {
+            box.classList.add('disabled');
+          }
+          box.addEventListener('click', () => this.handleTalentClick(talent));
+          row.appendChild(box);
+        });
+
+      this.gridEl.appendChild(row);
+    });
+  }
+
+  handleTalentClick(talent) {
+    if (this.game.talentManager.isTalentUnlocked(talent.id)) return;
+
+    if ((this.game.gameState.talentPoints || 0) <= 0) {
+      this.game.uiManager.print('You do not have any talent points.', 'error-message');
+      return;
+    }
+
+    const tierTaken = this.game.talentManager.acquired.some(id => {
+      const t = this.game.talentManager.getTalent(id);
+      return t && t.tier === talent.tier;
+    });
+    if (tierTaken) {
+      this.game.uiManager.print('You have already selected a talent for this tier.', 'system-message');
+      return;
+    }
+
+    const success = this.game.talentManager.unlockTalent(talent.id);
+    if (success) {
+      this.game.gameState.talentPoints -= 1;
+      this.updateContent();
+      this.game.uiManager.print(`Unlocked talent: ${talent.name}`, 'system-message');
+    } else {
+      this.game.uiManager.print('Cannot unlock this talent.', 'error-message');
+    }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -656,6 +656,43 @@ h1, h2, h3, h4, h5, h6 {
   cursor: pointer;
 }
 
+.talent-points {
+  padding: 5px 10px;
+  font-size: 14px;
+}
+
+.talent-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+}
+
+.talent-row {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.talent-option {
+  width: 60px;
+  height: 60px;
+  background-color: #24476a;
+  border: 1px solid #666;
+  border-radius: 4px;
+  cursor: pointer;
+  position: relative;
+}
+
+.talent-option.active {
+  background-color: #d4b123;
+}
+
+.talent-option.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 /* Audio Panel Styles */
 #audio-panel {
   position: fixed;

--- a/talents/talents.json
+++ b/talents/talents.json
@@ -1,24 +1,79 @@
 {
   "talents": [
     {
+      "id": "warrior_training",
+      "name": "Warrior Training",
+      "description": "Increase attack by 2.",
+      "requiredLevel": 1,
+      "tier": 1,
+      "effects": { "statBonuses": { "attack": 2 } }
+    },
+    {
+      "id": "defensive_posture",
+      "name": "Defensive Posture",
+      "description": "Increase defense by 2.",
+      "requiredLevel": 1,
+      "tier": 1,
+      "effects": { "statBonuses": { "defense": 2 } }
+    },
+    {
+      "id": "keen_mind",
+      "name": "Keen Mind",
+      "description": "Increase intelligence by 2.",
+      "requiredLevel": 1,
+      "tier": 1,
+      "effects": { "statBonuses": { "intelligence": 2 } }
+    },
+
+    {
       "id": "apprentice_mage",
       "name": "Apprentice Mage",
-      "description": "Study of basic magic, unlocking the Ice Bolt spell.",
-      "requiredLevel": 2,
-      "prerequisites": [],
-      "effects": {
-        "unlockSpell": "ice_bolt"
-      }
+      "description": "Unlocks the Ice Bolt spell.",
+      "requiredLevel": 3,
+      "tier": 2,
+      "effects": { "unlockSpell": "ice_bolt" }
     },
+    {
+      "id": "shield_master",
+      "name": "Shield Master",
+      "description": "Increase defense by 4.",
+      "requiredLevel": 3,
+      "tier": 2,
+      "effects": { "statBonuses": { "defense": 4 } }
+    },
+    {
+      "id": "swiftness",
+      "name": "Swiftness",
+      "description": "Increase speed by 3.",
+      "requiredLevel": 3,
+      "tier": 2,
+      "effects": { "statBonuses": { "speed": 3 } }
+    },
+
     {
       "id": "adept_mage",
       "name": "Adept Mage",
-      "description": "Advanced magical training, unlocking the Frost Nova spell.",
-      "requiredLevel": 4,
+      "description": "Unlocks the Frost Nova spell.",
+      "requiredLevel": 5,
+      "tier": 3,
       "prerequisites": ["apprentice_mage"],
-      "effects": {
-        "unlockSpell": "frost_nova"
-      }
+      "effects": { "unlockSpell": "frost_nova" }
+    },
+    {
+      "id": "berserker_rage",
+      "name": "Berserker Rage",
+      "description": "Increase attack by 5.",
+      "requiredLevel": 5,
+      "tier": 3,
+      "effects": { "statBonuses": { "attack": 5 } }
+    },
+    {
+      "id": "fortuitous",
+      "name": "Fortuitous",
+      "description": "Increase luck by 5.",
+      "requiredLevel": 5,
+      "tier": 3,
+      "effects": { "statBonuses": { "luck": 5 } }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- build new talent grid panel with points display
- style new talent grid and options
- implement tiered talent tree logic
- add 9 starter talents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5fbfaa4832894b94a1efb3464ca