### PR TITLE
Make inventory globally accessible

### DIFF
--- a/game.js
+++ b/game.js
@@ -498,6 +498,10 @@ class TextGame {
 
   // Toggle inventory panel
   toggleInventory() {
+    if (!this.isGameplayPhase() && !this.inputHandlers.isInitialAllocation) {
+      this.uiManager.print('Inventory can only be accessed during gameplay.', 'system-message');
+      return;
+    }
     if (this.inventoryPanel) {
       const show = !this.inventoryPanel.visible;
       if (show) {

--- a/js/inputHandlers.js
+++ b/js/inputHandlers.js
@@ -127,6 +127,11 @@ export class InputHandlers {
       return;
     }
 
+    if (input === "inventory" || input === "i") {
+      this.game.toggleInventory();
+      return;
+    }
+
     if (input === "talents" || input === "skills" || input === "talent") {
       this.game.toggleTalentTree();
       return;


### PR DESCRIPTION
## Summary
- allow the `inventory` command to be recognized in every input mode
- enforce gameplay-only access inside `toggleInventory`

## Testing
- `node --check js/inputHandlers.js && node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_6843cd8e80108328b1bee641a7aab8c7